### PR TITLE
Process material tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ Meshborn.vcxproj.user
 src/x64
 
 ####################
+# Mac specific
+####################
+.DS_Store
+
+####################
 # Automake intermediate files
 ####################
 /aclocal.m4
@@ -30,3 +35,5 @@ src/.libs/
 src/wavefront/.deps/
 src/wavefront/.dirstamp
 *.o
+*.lo
+*.la

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GLM V1.0.1
 
 ## Development status
 
-### Supported Wavefront tags
+### Supported Wavefront tags : object
 The following Wavefront obj tags are currently supported:
 
 | Tag                  | Status             | Notes                |
@@ -21,6 +21,21 @@ The following Wavefront obj tags are currently supported:
 | v (vertex)           | :white_check_mark: |                      |
 | vn (vertex normal)   | :white_check_mark: |                      |
 | vt (vertex texture)  | :x:                | Not implemented      |
+
+### Supported Wavefront tags : material
+The following Wavefront material tags are currently supported:
+
+| Tag                        | Status             | Notes                |
+|:---------------------------|:-------------------|:---------------------|
+| newmtl (new material)      | :white_check_mark: |                      |
+| Ka (ambient colour)        | :white_check_mark: |                      |
+| Kd (diffuse colour)        | :white_check_mark: |                      |
+| Ke (emissive colour)       | :white_check_mark: |                      |
+| Ks (specular colour)       | :white_check_mark: |                      |
+| Ns (specular exponent)     | :white_check_mark: |                      |
+| d (transparent disolve)    | :white_check_mark: |                      |
+| Ni (optical density)       | :white_check_mark: |                      |
+| illum (illumination_model) | :white_check_mark: |                      |
 
 ### Functionality implemented 
 The following functionality is currently supported:

--- a/README.md
+++ b/README.md
@@ -25,17 +25,25 @@ The following Wavefront obj tags are currently supported:
 ### Supported Wavefront tags : material
 The following Wavefront material tags are currently supported:
 
-| Tag                        | Status             | Notes                |
-|:---------------------------|:-------------------|:---------------------|
-| newmtl (new material)      | :white_check_mark: |                      |
-| Ka (ambient colour)        | :white_check_mark: |                      |
-| Kd (diffuse colour)        | :white_check_mark: |                      |
-| Ke (emissive colour)       | :white_check_mark: |                      |
-| Ks (specular colour)       | :white_check_mark: |                      |
-| Ns (specular exponent)     | :white_check_mark: |                      |
-| d (transparent disolve)    | :white_check_mark: |                      |
-| Ni (optical density)       | :white_check_mark: |                      |
-| illum (illumination_model) | :white_check_mark: |                      |
+| Tag                                 | Status             | Notes                |
+|:------------------------------------|:-------------------|:---------------------|
+| newmtl (new material)                 | :white_check_mark: |                      |
+| Ka (ambient colour)                   | :white_check_mark: |                      |
+| Kd (diffuse colour)                   | :white_check_mark: |                      |
+| Ke (emissive colour)                  | :white_check_mark: |                      |
+| Ks (specular colour)                  | :white_check_mark: |                      |
+| Ns (specular exponent)                | :white_check_mark: |                      |
+| d (transparent disolve)               | :white_check_mark: |                      |
+| Ni (optical density)                  | :white_check_mark: |                      |
+| illum (illumination model)            | :white_check_mark: |                      |
+| map_Ka (ambient texture map)          | :x:                |                      |
+| map_Kd (diffuse texture map)          | :x:                |                      |
+| map_Ks (specular color texture map)   | :x:                |                      |
+| map_Ns (specular highlight component) | :x:                |                      |
+| map_d (alpha texture map)             | :x:                |                      |
+| map_bump/bump (bump map)              | :x:                |                      |
+| disp (displacement map)               | :x:                |                      |
+| decal (stencil decal texture)         | :x:                |                      |
 
 ### Functionality implemented 
 The following functionality is currently supported:

--- a/src/LoggerManager.h
+++ b/src/LoggerManager.h
@@ -60,13 +60,14 @@ class LoggerManager {
     #define SHOULD_LOG_DEBUG false
   #endif
 
-  #define LOG(level, message)                                                             \
-    do {                                                                                  \
-      if (Logger::LoggerManager::Instance().HasLogger()) {                                \
-        if ((level) != Logger::LogLevel::Debug || SHOULD_LOG_DEBUG) {                             \
-          Logger::LoggerManager::Instance().GetLogger().Log((level), (message));          \
-        }                                                                                 \
-      }                                                                                   \
+  #define LOG(level, message)                                           \
+    do {                                                                \
+      if (Logger::LoggerManager::Instance().HasLogger()) {              \
+        if ((level) != Logger::LogLevel::Debug || SHOULD_LOG_DEBUG) {   \
+          Logger::LoggerManager::Instance().GetLogger().Log((level),    \
+                                                            (message)); \
+        }                                                               \
+      }                                                                 \
     } while (0)
 #else
   #define LOG(level, message) do {} while (0)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,8 @@ lib_LTLIBRARIES = libMeshborn.la
 libMeshborn_la_SOURCES = Meshborn.cpp                        \
                          wavefront/WavefrontObjLoader.cpp    \
                          wavefront/BaseWavefrontParser.cpp   \
-                         wavefront/MaterialLibraryParser.cpp
+                         wavefront/MaterialLibraryParser.cpp  \
+                         Material.cpp
 
 # Set the libtool versioning
 #libWebLoom_la_LDFLAGS = -version-info $(LT_VERSION)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,8 +18,10 @@ includedir = $(prefix)/include/meshborn
 
 # Specify sources and output shared library
 lib_LTLIBRARIES = libMeshborn.la
-libMeshborn_la_SOURCES = Meshborn.cpp \
-                         wavefront/WavefrontObjLoader.cpp
+libMeshborn_la_SOURCES = Meshborn.cpp                        \
+                         wavefront/WavefrontObjLoader.cpp    \
+                         wavefront/BaseWavefrontParser.cpp   \
+                         wavefront/MaterialLibraryParser.cpp
 
 # Set the libtool versioning
 #libWebLoom_la_LDFLAGS = -version-info $(LT_VERSION)

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -53,12 +53,12 @@ void Material::SetAmbientColour(glm::vec3 colour) {
  * @param[out] colour The ambient colour will be stored here if set.
  * @return true if the ambient colour was set and returned; false otherwise.
  */
-bool Material::GetAmbientColour(glm::vec3 &colour) {
+bool Material::GetAmbientColour(glm::vec3 *colour) {
     if (!ambientColourSet_) {
         return false;
     }
 
-    colour = ambientColour_;
+    *colour = ambientColour_;
     return true;
 }
 
@@ -78,12 +78,12 @@ void Material::SetDiffuseColour(glm::vec3 colour) {
  * @param[out] colour The diffuse colour will be stored here if set.
  * @return true if the diffuse colour was set and returned; false otherwise.
  */
-bool Material::GetDiffuseColour(glm::vec3 &colour) {
+bool Material::GetDiffuseColour(glm::vec3 *colour) {
     if (!diffuseColourSet_) {
         return false;
     }
 
-    colour = diffuseColour_;
+    *colour = diffuseColour_;
     return true;
 }
 
@@ -110,12 +110,12 @@ void Material::SetSpecularColour(glm::vec3 colour) {
  * @param[out] colour Reference to a glm::vec3 to receive the specular colour.
  * @return true if the specular colour has been set, false otherwise.
  */
-bool Material::GetSpecularColour(glm::vec3 &colour) {
+bool Material::GetSpecularColour(glm::vec3 *colour) {
     if (!specularColourSet_) {
         return false;
     }
 
-    colour = specularColour_;
+    *colour = specularColour_;
     return true;
 }
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -1,0 +1,26 @@
+/*
+Meshborn
+Copyright (C) 2025  SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "Material.h"
+
+namespace Meshborn {
+
+    class Material {
+    };
+    
+}   // namespace Meshborn
+    

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -161,5 +161,18 @@ bool Material::GetOpticalDensity(float *density) {
     return true;
 }
 
+void Material::SetTransparentDissolve(float transparency) {
+    transparentDissolve_ = transparency;
+    transparentDissolveSet_ = true;
+}
+
+bool Material::GetTransparentDissolve(float *transparency) {
+    if (!transparentDissolveSet_) {
+        return false;
+    }
+
+    *transparency = transparentDissolve_;
+    return true;
+}
 
 }   // namespace Meshborn

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -175,4 +175,116 @@ bool Material::GetTransparentDissolve(float *transparency) {
     return true;
 }
 
+void Material::SetAmbientTextureMap(std::string map) {
+    ambientTextureMap_ = map;
+    ambientTextureMapSet_ = true;
+}
+
+bool Material::GetAmbientTextureMap(std::string &map) {
+    if (!ambientTextureMapSet_) {
+        return false;
+    }
+
+    map = ambientTextureMap_;
+    return true;
+}
+
+void Material::SetDiffuseTextureMap(std::string map) {
+    diffuseTextureMap_ = map;
+    diffuseTextureMapSet_ = true;
+}
+
+bool Material::GetDiffuseTextureMap(std::string &map) {
+    if (!diffuseTextureMapSet_) {
+        return false;
+    }
+
+    map = diffuseTextureMap_;
+    return true;
+}
+
+void Material::SetSpecularColourTextureMap(std::string map) {
+    specularColourTextureMap_ = map;
+    specularColourTextureMapSet_ = true;
+}
+
+bool Material::GetSpecularColourTextureMap(std::string &map) {
+    if (!specularColourTextureMapSet_) {
+        return false;
+    }
+
+    map = specularColourTextureMap_;
+    return true;
+}
+
+void Material::SetSpecularHighlightComponent(std::string map) {
+    specularHighlightComponent_ = map;
+    specularHighlightComponentSet_ = true;
+}
+
+bool Material::GetSpecularHighlightComponent(std::string &map) {
+    if (!specularHighlightComponentSet_) {
+        return false;
+    }
+
+    map = specularHighlightComponent_;
+    return true;
+}
+
+void Material::SetAlphaTextureMap(std::string map) {
+    alphaTextureMap_ = map;
+    alphaTextureMapSet_ = true;
+}
+
+bool Material::GetAlphaTextureMap(std::string &map) {
+    if (!alphaTextureMapSet_) {
+        return false;
+    }
+
+    map = alphaTextureMap_;
+    return true;
+}
+
+void Material::SetBumpMap(std::string map) {
+    bumpMap_ = map;
+    bumpMapSet_ = true;
+}
+
+bool Material::GetBumpMap(std::string &map) {
+    if (!bumpMapSet_) {
+        return false;
+    }
+
+    map = bumpMap_;
+    return true;
+}
+
+void Material::SetDisplacementMap(std::string map) {
+    displacementMap_ = map;
+    displacementMapSet_ = true;
+}
+
+bool Material::GetDisplacementMap(std::string &map) {
+    if (!displacementMapSet_) {
+        return false;
+    }
+
+    map = displacementMap_;
+    return true;
+}
+
+void Material::SetStencilDecalTexture(std::string map) {
+    stencilDecalTexture_ = map;
+    stencilDecalTextureSet_ = true;
+}
+
+bool Material::GetStencilDecalTexture(std::string &map) {
+    if (!stencilDecalTextureSet_) {
+        return false;
+    }
+
+    map = stencilDecalTexture_;
+    return true;
+}
+
 }   // namespace Meshborn

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -147,4 +147,19 @@ bool Material::GetIlluminationModel(int *model) {
     return true;
 }
 
+void Material::SetOpticalDensity(float density) {
+    opticalDensity_ = density;
+    opticalDensitySet_ = true;
+}
+
+bool Material::GetOpticalDensity(float *density) {
+    if (!opticalDensitySet_) {
+        return false;
+    }
+
+    *density = opticalDensity_;
+    return true;
+}
+
+
 }   // namespace Meshborn

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -27,8 +27,14 @@ namespace Meshborn {
  * @param name The name of the material.
  */
 Material::Material(std::string name) : name_(name) {
-    glm::vec3 ambientColour_ = glm::vec3(0.0f, 0.0f, 0.0f);
+    ambientColour_ = glm::vec3(0.0f, 0.0f, 0.0f);
     ambientColourSet_ = false;
+
+    diffuseColour_ = glm::vec3(0.0f, 0.0f, 0.0f);
+    diffuseColourSet_ = false;
+
+    specularColour_ = glm::vec3(0.0f, 0.0f, 0.0f);
+    specularColourSet_ = false;
 }
 
 /**
@@ -81,5 +87,36 @@ bool Material::GetDiffuseColour(glm::vec3 &colour) {
     return true;
 }
 
+/**
+ * @brief Sets the specular colour of the material.
+ *
+ * This method assigns the given RGB colour vector to the material's specular
+ * colour and marks it as explicitly set.
+ *
+ * @param colour The RGB colour value to use as the material's specular colour.
+ */
+void Material::SetSpecularColour(glm::vec3 colour) {
+    specularColour_ = colour;
+    specularColourSet_ = true;
+}
+
+/**
+ * @brief Retrieves the specular colour of the material, if set.
+ *
+ * If the specular colour has been set previously, this method copies the stored
+ * colour into the provided reference and returns true. If not, it returns false
+ * without modifying the reference.
+ *
+ * @param[out] colour Reference to a glm::vec3 to receive the specular colour.
+ * @return true if the specular colour has been set, false otherwise.
+ */
+bool Material::GetSpecularColour(glm::vec3 &colour) {
+    if (!specularColourSet_) {
+        return false;
+    }
+
+    colour = specularColour_;
+    return true;
+}
+
 }   // namespace Meshborn
-    

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -133,11 +133,28 @@ bool Material::GetSpecularColour(glm::vec3 *colour) {
     return true;
 }
 
+/**
+ * @brief Sets the illumination model for the material.
+ *
+ * This method sets the illumination model, which defines how the material
+ * interacts with light (e.g., diffuse, specular, reflection).
+ *
+ * @param model The illumination model index to set.
+ */
 void Material::SetIlluminationModel(int model) {
     illuminationModel_ = model;
     illuminationModelSet_ = true;
 }
 
+/**
+ * @brief Retrieves the current illumination model.
+ *
+ * Returns the stored illumination model if it has been set. Otherwise,
+ * returns false.
+ *
+ * @param model Pointer to an integer where the model will be stored.
+ * @return true if the model was set and retrieved, false otherwise.
+ */
 bool Material::GetIlluminationModel(int *model) {
     if (!illuminationModelSet_) {
         return false;
@@ -147,11 +164,28 @@ bool Material::GetIlluminationModel(int *model) {
     return true;
 }
 
+/**
+ * @brief Sets the optical density (index of refraction) of the material.
+ *
+ * Optical density affects how much light bends as it enters the material.
+ * Common values range from 1.0 to 2.0, depending on the material type.
+ *
+ * @param density The optical density value to set.
+ */
 void Material::SetOpticalDensity(float density) {
     opticalDensity_ = density;
     opticalDensitySet_ = true;
 }
 
+/**
+ * @brief Retrieves the current optical density value.
+ *
+ * Returns the stored optical density if it has been set. Otherwise,
+ * returns false.
+ *
+ * @param density Pointer to a float where the value will be stored.
+ * @return true if the value was set and retrieved, false otherwise.
+ */
 bool Material::GetOpticalDensity(float *density) {
     if (!opticalDensitySet_) {
         return false;
@@ -161,11 +195,29 @@ bool Material::GetOpticalDensity(float *density) {
     return true;
 }
 
+/**
+ * @brief Sets the transparent dissolve value for the material.
+ *
+ * This value defines how transparent the material is:
+ *   - 1.0 = fully opaque
+ *   - 0.0 = fully transparent
+ *
+ * @param transparency The transparency value to set (range: 0.0 to 1.0).
+ */
 void Material::SetTransparentDissolve(float transparency) {
     transparentDissolve_ = transparency;
     transparentDissolveSet_ = true;
 }
 
+/**
+ * @brief Retrieves the transparent dissolve value for the material.
+ *
+ * Returns the stored transparency value if it has been set. Otherwise,
+ * returns false.
+ *
+ * @param transparency Pointer to a float to store the transparency value.
+ * @return true if the value was set and retrieved, false otherwise.
+ */
 bool Material::GetTransparentDissolve(float *transparency) {
     if (!transparentDissolveSet_) {
         return false;
@@ -175,11 +227,27 @@ bool Material::GetTransparentDissolve(float *transparency) {
     return true;
 }
 
+/**
+ * @brief Sets the ambient texture map path for the material.
+ *
+ * This defines the texture used for ambient lighting on the material.
+ *
+ * @param map The file path to the ambient texture map.
+ */
 void Material::SetAmbientTextureMap(std::string map) {
     ambientTextureMap_ = map;
     ambientTextureMapSet_ = true;
 }
 
+/**
+ * @brief Retrieves the ambient texture map path for the material.
+ *
+ * Returns the stored texture map path if it has been set. Otherwise,
+ * returns false.
+ *
+ * @param map Pointer to a string where the map path will be stored.
+ * @return true if the map was set and retrieved, false otherwise.
+ */
 bool Material::GetAmbientTextureMap(std::string *map) {
     if (!ambientTextureMapSet_) {
         return false;
@@ -189,11 +257,28 @@ bool Material::GetAmbientTextureMap(std::string *map) {
     return true;
 }
 
+/**
+ * @brief Sets the diffuse texture map path for the material.
+ *
+ * The diffuse texture defines the base color and surface detail of the
+ * material under direct lighting.
+ *
+ * @param map The file path to the diffuse texture map.
+ */
 void Material::SetDiffuseTextureMap(std::string map) {
     diffuseTextureMap_ = map;
     diffuseTextureMapSet_ = true;
 }
 
+/**
+ * @brief Retrieves the diffuse texture map path for the material.
+ *
+ * Returns the stored diffuse texture map path if it has been set. Otherwise,
+ * returns false.
+ *
+ * @param map Pointer to a string where the map path will be stored.
+ * @return true if the map was set and retrieved, false otherwise.
+ */
 bool Material::GetDiffuseTextureMap(std::string *map) {
     if (!diffuseTextureMapSet_) {
         return false;
@@ -203,11 +288,28 @@ bool Material::GetDiffuseTextureMap(std::string *map) {
     return true;
 }
 
+/**
+ * @brief Sets the specular colour texture map path for the material.
+ *
+ * This texture map defines the color and intensity of specular highlights,
+ * affecting how shiny or reflective the surface appears.
+ *
+ * @param map The file path to the specular colour texture map.
+ */
 void Material::SetSpecularColourTextureMap(std::string map) {
     specularColourTextureMap_ = map;
     specularColourTextureMapSet_ = true;
 }
 
+/**
+ * @brief Retrieves the specular colour texture map path for the material.
+ *
+ * Returns the stored specular colour texture map path if it has been set.
+ * Otherwise, returns false.
+ *
+ * @param map Pointer to a string where the map path will be stored.
+ * @return true if the map was set and retrieved, false otherwise.
+ */
 bool Material::GetSpecularColourTextureMap(std::string *map) {
     if (!specularColourTextureMapSet_) {
         return false;

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -19,8 +19,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace Meshborn {
 
-    class Material {
-    };
-    
+Material::Material(std::string name) : name_(name) {
+    glm::vec3 ambientColour_ = glm::vec3(0.0f, 0.0f, 0.0f);
+    ambientColourSet_ = false;
+}
+
+void Material::SetAmbientColour(glm::vec3 colour) {
+    ambientColour_ = colour;
+    ambientColourSet_ = true;
+}
+
+bool Material::GetAmbientColour(glm::vec3 &colour) {
+    if (!ambientColourSet_) {
+        return false;
+    }
+
+    colour = ambientColour_;
+    return true;
+}
+
 }   // namespace Meshborn
     

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -37,6 +37,10 @@ Material::Material(std::string name) : name_(name) {
     specularColourSet_ = false;
 }
 
+std::string Material::GetName() {
+    return name_;
+}
+
 /**
  * @brief Sets the ambient colour of the material.
  * 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -19,22 +19,65 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace Meshborn {
 
+    /**
+ * @brief Constructs a new Material with the given name.
+ * 
+ * Initializes the ambient colour to black (0, 0, 0) and marks it as unset.
+ * 
+ * @param name The name of the material.
+ */
 Material::Material(std::string name) : name_(name) {
     glm::vec3 ambientColour_ = glm::vec3(0.0f, 0.0f, 0.0f);
     ambientColourSet_ = false;
 }
 
+/**
+ * @brief Sets the ambient colour of the material.
+ * 
+ * @param colour A glm::vec3 representing the ambient RGB colour values.
+ */
 void Material::SetAmbientColour(glm::vec3 colour) {
     ambientColour_ = colour;
     ambientColourSet_ = true;
 }
 
+/**
+ * @brief Retrieves the ambient colour of the material.
+ * 
+ * @param[out] colour The ambient colour will be stored here if set.
+ * @return true if the ambient colour was set and returned; false otherwise.
+ */
 bool Material::GetAmbientColour(glm::vec3 &colour) {
     if (!ambientColourSet_) {
         return false;
     }
 
     colour = ambientColour_;
+    return true;
+}
+
+/**
+ * @brief Sets the diffuse colour of the material.
+ * 
+ * @param colour A glm::vec3 representing the diffuse RGB colour values.
+ */
+void Material::SetDiffuseColour(glm::vec3 colour) {
+    diffuseColour_ = colour;
+    diffuseColourSet_ = true;
+}
+
+/**
+ * @brief Retrieves the diffuse colour of the material.
+ * 
+ * @param[out] colour The diffuse colour will be stored here if set.
+ * @return true if the diffuse colour was set and returned; false otherwise.
+ */
+bool Material::GetDiffuseColour(glm::vec3 &colour) {
+    if (!diffuseColourSet_) {
+        return false;
+    }
+
+    colour = diffuseColour_;
     return true;
 }
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -87,11 +87,28 @@ bool Material::GetDiffuseColour(glm::vec3 *colour) {
     return true;
 }
 
+/**
+ * @brief Sets the emissive color for the material.
+ *
+ * The emissive color defines how much light the material emits, independent
+ * of lighting. This makes the material appear self-illuminating.
+ *
+ * @param colour The emissive color to set (represented as a glm::vec3).
+ */
 void Material::SetEmissiveColour(glm::vec3 colour) {
     emissiveColour_ = colour;
     emissiveColourSet_ = true;
 }
 
+/**
+ * @brief Retrieves the emissive color for the material.
+ *
+ * Returns the stored emissive color if it has been set. Otherwise, returns
+ * false.
+ *
+ * @param colour Pointer to a glm::vec3 to store the emissive color.
+ * @return true if the color was set and retrieved, false otherwise.
+ */
 bool Material::GetEmissiveColour(glm::vec3 *colour) {
     if (!emissiveColourSet_) {
         return false;

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -87,6 +87,20 @@ bool Material::GetDiffuseColour(glm::vec3 *colour) {
     return true;
 }
 
+void Material::SetEmissiveColour(glm::vec3 colour) {
+    emissiveColour_ = colour;
+    emissiveColourSet_ = true;
+}
+
+bool Material::GetEmissiveColour(glm::vec3 *colour) {
+    if (!emissiveColourSet_) {
+        return false;
+    }
+
+    *colour = emissiveColour_;
+    return true;
+}
+
 /**
  * @brief Sets the specular colour of the material.
  *

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -319,11 +319,28 @@ bool Material::GetSpecularColourTextureMap(std::string *map) {
     return true;
 }
 
+/**
+ * @brief Sets the specular highlight component texture map path.
+ *
+ * This texture map controls the specular exponent or sharpness of specular
+ * highlights on the material surface.
+ *
+ * @param map The file path to the specular highlight component texture map.
+ */
 void Material::SetSpecularHighlightComponent(std::string map) {
     specularHighlightComponent_ = map;
     specularHighlightComponentSet_ = true;
 }
 
+/**
+ * @brief Retrieves the specular highlight component texture map path.
+ *
+ * Returns the stored specular highlight component map path if it has been
+ * set. Otherwise, returns false.
+ *
+ * @param map Pointer to a string where the map path will be stored.
+ * @return true if the map was set and retrieved, false otherwise.
+ */
 bool Material::GetSpecularHighlightComponent(std::string *map) {
     if (!specularHighlightComponentSet_) {
         return false;
@@ -333,11 +350,28 @@ bool Material::GetSpecularHighlightComponent(std::string *map) {
     return true;
 }
 
+/**
+ * @brief Sets the alpha texture map path for the material.
+ *
+ * The alpha texture map defines transparency information for the material,
+ * typically used for masking or fading parts of the surface.
+ *
+ * @param map The file path to the alpha texture map.
+ */
 void Material::SetAlphaTextureMap(std::string map) {
     alphaTextureMap_ = map;
     alphaTextureMapSet_ = true;
 }
 
+/**
+ * @brief Retrieves the alpha texture map path for the material.
+ *
+ * Returns the stored alpha texture map path if it has been set. Otherwise,
+ * returns false.
+ *
+ * @param map Pointer to a string where the map path will be stored.
+ * @return true if the map was set and retrieved, false otherwise.
+ */
 bool Material::GetAlphaTextureMap(std::string *map) {
     if (!alphaTextureMapSet_) {
         return false;
@@ -347,11 +381,28 @@ bool Material::GetAlphaTextureMap(std::string *map) {
     return true;
 }
 
+/**
+ * @brief Sets the bump map texture path for the material.
+ *
+ * The bump map simulates small surface variations to create the illusion of
+ * surface detail without adding actual geometry.
+ *
+ * @param map The file path to the bump map texture.
+ */
 void Material::SetBumpMap(std::string map) {
     bumpMap_ = map;
     bumpMapSet_ = true;
 }
 
+/**
+ * @brief Retrieves the bump map texture path for the material.
+ *
+ * Returns the stored bump map texture path if it has been set. Otherwise,
+ * returns false.
+ *
+ * @param map Pointer to a string where the bump map path will be stored.
+ * @return true if the map was set and retrieved, false otherwise.
+ */
 bool Material::GetBumpMap(std::string *map) {
     if (!bumpMapSet_) {
         return false;
@@ -361,11 +412,29 @@ bool Material::GetBumpMap(std::string *map) {
     return true;
 }
 
+/**
+ * @brief Sets the displacement map texture path for the material.
+ *
+ * The displacement map alters the actual surface geometry of the material
+ * by modifying its vertices based on the map's data.
+ *
+ * @param map The file path to the displacement map texture.
+ */
 void Material::SetDisplacementMap(std::string map) {
     displacementMap_ = map;
     displacementMapSet_ = true;
 }
 
+/**
+ * @brief Retrieves the displacement map texture path for the material.
+ *
+ * Returns the stored displacement map texture path if it has been set.
+ * Otherwise, returns false.
+ *
+ * @param map Pointer to a string where the displacement map path will be
+ * stored.
+ * @return true if the map was set and retrieved, false otherwise.
+ */
 bool Material::GetDisplacementMap(std::string *map) {
     if (!displacementMapSet_) {
         return false;
@@ -375,11 +444,29 @@ bool Material::GetDisplacementMap(std::string *map) {
     return true;
 }
 
+/**
+ * @brief Sets the stencil decal texture path for the material.
+ *
+ * The stencil decal texture is used for applying patterns or effects on
+ * specific areas of the material's surface, typically for detail work.
+ *
+ * @param map The file path to the stencil decal texture.
+ */
 void Material::SetStencilDecalTexture(std::string map) {
     stencilDecalTexture_ = map;
     stencilDecalTextureSet_ = true;
 }
 
+/**
+ * @brief Retrieves the stencil decal texture path for the material.
+ *
+ * Returns the stored stencil decal texture path if it has been set.
+ * Otherwise, returns false.
+ *
+ * @param map Pointer to a string where the stencil decal texture path will
+ * be stored.
+ * @return true if the map was set and retrieved, false otherwise.
+ */
 bool Material::GetStencilDecalTexture(std::string *map) {
     if (!stencilDecalTextureSet_) {
         return false;

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -180,12 +180,12 @@ void Material::SetAmbientTextureMap(std::string map) {
     ambientTextureMapSet_ = true;
 }
 
-bool Material::GetAmbientTextureMap(std::string &map) {
+bool Material::GetAmbientTextureMap(std::string *map) {
     if (!ambientTextureMapSet_) {
         return false;
     }
 
-    map = ambientTextureMap_;
+    *map = ambientTextureMap_;
     return true;
 }
 
@@ -194,12 +194,12 @@ void Material::SetDiffuseTextureMap(std::string map) {
     diffuseTextureMapSet_ = true;
 }
 
-bool Material::GetDiffuseTextureMap(std::string &map) {
+bool Material::GetDiffuseTextureMap(std::string *map) {
     if (!diffuseTextureMapSet_) {
         return false;
     }
 
-    map = diffuseTextureMap_;
+    *map = diffuseTextureMap_;
     return true;
 }
 
@@ -208,12 +208,12 @@ void Material::SetSpecularColourTextureMap(std::string map) {
     specularColourTextureMapSet_ = true;
 }
 
-bool Material::GetSpecularColourTextureMap(std::string &map) {
+bool Material::GetSpecularColourTextureMap(std::string *map) {
     if (!specularColourTextureMapSet_) {
         return false;
     }
 
-    map = specularColourTextureMap_;
+    *map = specularColourTextureMap_;
     return true;
 }
 
@@ -222,12 +222,12 @@ void Material::SetSpecularHighlightComponent(std::string map) {
     specularHighlightComponentSet_ = true;
 }
 
-bool Material::GetSpecularHighlightComponent(std::string &map) {
+bool Material::GetSpecularHighlightComponent(std::string *map) {
     if (!specularHighlightComponentSet_) {
         return false;
     }
 
-    map = specularHighlightComponent_;
+    *map = specularHighlightComponent_;
     return true;
 }
 
@@ -236,12 +236,12 @@ void Material::SetAlphaTextureMap(std::string map) {
     alphaTextureMapSet_ = true;
 }
 
-bool Material::GetAlphaTextureMap(std::string &map) {
+bool Material::GetAlphaTextureMap(std::string *map) {
     if (!alphaTextureMapSet_) {
         return false;
     }
 
-    map = alphaTextureMap_;
+    *map = alphaTextureMap_;
     return true;
 }
 
@@ -250,12 +250,12 @@ void Material::SetBumpMap(std::string map) {
     bumpMapSet_ = true;
 }
 
-bool Material::GetBumpMap(std::string &map) {
+bool Material::GetBumpMap(std::string *map) {
     if (!bumpMapSet_) {
         return false;
     }
 
-    map = bumpMap_;
+    *map = bumpMap_;
     return true;
 }
 
@@ -264,12 +264,12 @@ void Material::SetDisplacementMap(std::string map) {
     displacementMapSet_ = true;
 }
 
-bool Material::GetDisplacementMap(std::string &map) {
+bool Material::GetDisplacementMap(std::string *map) {
     if (!displacementMapSet_) {
         return false;
     }
 
-    map = displacementMap_;
+    *map = displacementMap_;
     return true;
 }
 
@@ -278,12 +278,12 @@ void Material::SetStencilDecalTexture(std::string map) {
     stencilDecalTextureSet_ = true;
 }
 
-bool Material::GetStencilDecalTexture(std::string &map) {
+bool Material::GetStencilDecalTexture(std::string *map) {
     if (!stencilDecalTextureSet_) {
         return false;
     }
 
-    map = stencilDecalTexture_;
+    *map = stencilDecalTexture_;
     return true;
 }
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -133,4 +133,18 @@ bool Material::GetSpecularColour(glm::vec3 *colour) {
     return true;
 }
 
+void Material::SetIlluminationModel(int model) {
+    illuminationModel_ = model;
+    illuminationModelSet_ = true;
+}
+
+bool Material::GetIlluminationModel(int *model) {
+    if (!illuminationModelSet_) {
+        return false;
+    }
+
+    *model = illuminationModel_;
+    return true;
+}
+
 }   // namespace Meshborn

--- a/src/Material.h
+++ b/src/Material.h
@@ -1,0 +1,36 @@
+/*
+Meshborn
+Copyright (C) 2025  SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef MATERIAL_H_
+#define MATERIAL_H_
+#include <string>
+#include "glm/glm.hpp"
+
+namespace Meshborn {
+
+class Material {
+public:
+    Material();
+
+private:
+    std::string name_;
+    glm::vec3 ambientColour_;
+};
+
+}   // namespace Meshborn
+
+#endif  // MATERIAL_H_

--- a/src/Material.h
+++ b/src/Material.h
@@ -48,28 +48,28 @@ class Material {
     bool GetTransparentDissolve(float *transparency);
 
     void SetAmbientTextureMap(std::string map);
-    bool GetAmbientTextureMap(std::string &map);
+    bool GetAmbientTextureMap(std::string *map);
 
     void SetDiffuseTextureMap(std::string map);
-    bool GetDiffuseTextureMap(std::string &map);
+    bool GetDiffuseTextureMap(std::string *map);
 
     void SetSpecularColourTextureMap(std::string map);
-    bool GetSpecularColourTextureMap(std::string &map);
+    bool GetSpecularColourTextureMap(std::string *map);
 
     void SetSpecularHighlightComponent(std::string map);
-    bool GetSpecularHighlightComponent(std::string &map);
+    bool GetSpecularHighlightComponent(std::string *map);
 
     void SetAlphaTextureMap(std::string map);
-    bool GetAlphaTextureMap(std::string &map);
+    bool GetAlphaTextureMap(std::string *map);
 
     void SetBumpMap(std::string map);
-    bool GetBumpMap(std::string &map);
+    bool GetBumpMap(std::string *map);
 
     void SetDisplacementMap(std::string map);
-    bool GetDisplacementMap(std::string &map);
+    bool GetDisplacementMap(std::string *map);
 
     void SetStencilDecalTexture(std::string map);
-    bool GetStencilDecalTexture(std::string &map);
+    bool GetStencilDecalTexture(std::string *map);
 
  private:
     std::string name_;

--- a/src/Material.h
+++ b/src/Material.h
@@ -24,7 +24,7 @@ namespace Meshborn {
 
 class Material {
  public:
-    Material(std::string name);
+    explicit Material(std::string name);
 
     void SetAmbientColour(glm::vec3 colour);
     bool GetAmbientColour(glm::vec3 *colour);

--- a/src/Material.h
+++ b/src/Material.h
@@ -27,13 +27,13 @@ class Material {
     Material(std::string name);
 
     void SetAmbientColour(glm::vec3 colour);
-    bool GetAmbientColour(glm::vec3 &colour);
+    bool GetAmbientColour(glm::vec3 *colour);
 
     void SetDiffuseColour(glm::vec3 colour);
-    bool GetDiffuseColour(glm::vec3 &colour);
+    bool GetDiffuseColour(glm::vec3 *colour);
 
     void SetSpecularColour(glm::vec3 colour);
-    bool GetSpecularColour(glm::vec3 &colour);
+    bool GetSpecularColour(glm::vec3 *colour);
 
  private:
     std::string name_;

--- a/src/Material.h
+++ b/src/Material.h
@@ -24,11 +24,15 @@ namespace Meshborn {
 
 class Material {
 public:
-    Material();
+    Material(std::string name);
+
+    void SetAmbientColour(glm::vec3 colour);
+    bool GetAmbientColour(glm::vec3 &colour);
 
 private:
     std::string name_;
     glm::vec3 ambientColour_;
+    bool ambientColourSet_;
 };
 
 }   // namespace Meshborn

--- a/src/Material.h
+++ b/src/Material.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Meshborn {
 
 class Material {
-public:
+ public:
     Material(std::string name);
 
     void SetAmbientColour(glm::vec3 colour);
@@ -32,7 +32,10 @@ public:
     void SetDiffuseColour(glm::vec3 colour);
     bool GetDiffuseColour(glm::vec3 &colour);
 
-private:
+    void SetSpecularColour(glm::vec3 colour);
+    bool GetSpecularColour(glm::vec3 &colour);
+
+ private:
     std::string name_;
 
     // Ambient colour
@@ -43,6 +46,9 @@ private:
     glm::vec3 diffuseColour_;
     bool diffuseColourSet_;
 
+    // Specular colour
+    glm::vec3 specularColour_;
+    bool specularColourSet_;
 };
 
 }   // namespace Meshborn

--- a/src/Material.h
+++ b/src/Material.h
@@ -32,6 +32,9 @@ class Material {
     void SetDiffuseColour(glm::vec3 colour);
     bool GetDiffuseColour(glm::vec3 *colour);
 
+    void SetEmissiveColour(glm::vec3 colour);
+    bool GetEmissiveColour(glm::vec3 *colour);
+
     void SetSpecularColour(glm::vec3 colour);
     bool GetSpecularColour(glm::vec3 *colour);
 
@@ -45,6 +48,10 @@ class Material {
     // Diffuse colour
     glm::vec3 diffuseColour_;
     bool diffuseColourSet_;
+
+    // Emissive colour
+    glm::vec3 emissiveColour_;
+    bool emissiveColourSet_;
 
     // Specular colour
     glm::vec3 specularColour_;

--- a/src/Material.h
+++ b/src/Material.h
@@ -38,6 +38,9 @@ class Material {
     void SetSpecularColour(glm::vec3 colour);
     bool GetSpecularColour(glm::vec3 *colour);
 
+    void SetIlluminationModel(int model);
+    bool GetIlluminationModel(int *model);
+
  private:
     std::string name_;
 
@@ -56,6 +59,10 @@ class Material {
     // Specular colour
     glm::vec3 specularColour_;
     bool specularColourSet_;
+
+    // Illumination model
+    int illuminationModel_;
+    bool illuminationModelSet_;
 };
 
 }   // namespace Meshborn

--- a/src/Material.h
+++ b/src/Material.h
@@ -26,6 +26,8 @@ class Material {
  public:
     explicit Material(std::string name);
 
+    std::string GetName();
+
     void SetAmbientColour(glm::vec3 colour);
     bool GetAmbientColour(glm::vec3 *colour);
 

--- a/src/Material.h
+++ b/src/Material.h
@@ -29,10 +29,20 @@ public:
     void SetAmbientColour(glm::vec3 colour);
     bool GetAmbientColour(glm::vec3 &colour);
 
+    void SetDiffuseColour(glm::vec3 colour);
+    bool GetDiffuseColour(glm::vec3 &colour);
+
 private:
     std::string name_;
+
+    // Ambient colour
     glm::vec3 ambientColour_;
     bool ambientColourSet_;
+
+    // Diffuse colour
+    glm::vec3 diffuseColour_;
+    bool diffuseColourSet_;
+
 };
 
 }   // namespace Meshborn

--- a/src/Material.h
+++ b/src/Material.h
@@ -47,6 +47,30 @@ class Material {
     void SetTransparentDissolve(float transparency);
     bool GetTransparentDissolve(float *transparency);
 
+    void SetAmbientTextureMap(std::string map);
+    bool GetAmbientTextureMap(std::string &map);
+
+    void SetDiffuseTextureMap(std::string map);
+    bool GetDiffuseTextureMap(std::string &map);
+
+    void SetSpecularColourTextureMap(std::string map);
+    bool GetSpecularColourTextureMap(std::string &map);
+
+    void SetSpecularHighlightComponent(std::string map);
+    bool GetSpecularHighlightComponent(std::string &map);
+
+    void SetAlphaTextureMap(std::string map);
+    bool GetAlphaTextureMap(std::string &map);
+
+    void SetBumpMap(std::string map);
+    bool GetBumpMap(std::string &map);
+
+    void SetDisplacementMap(std::string map);
+    bool GetDisplacementMap(std::string &map);
+
+    void SetStencilDecalTexture(std::string map);
+    bool GetStencilDecalTexture(std::string &map);
+
  private:
     std::string name_;
 
@@ -77,6 +101,38 @@ class Material {
     // Transparent dissolve
     float transparentDissolve_;
     bool transparentDissolveSet_;
+
+    // Ambient texture map
+    std::string ambientTextureMap_;
+    bool ambientTextureMapSet_;
+
+    // Diffuse texture map
+    std::string diffuseTextureMap_;
+    bool diffuseTextureMapSet_;
+
+    // Specular colour texture map
+    std::string specularColourTextureMap_;
+    bool specularColourTextureMapSet_;
+
+    // Specular highlight component
+    std::string specularHighlightComponent_;
+    bool specularHighlightComponentSet_;
+
+    // Alpha texture map
+    std::string alphaTextureMap_;
+    bool alphaTextureMapSet_;
+
+    // Bump map
+    std::string bumpMap_;
+    bool bumpMapSet_;
+
+    // Displacement map
+    std::string displacementMap_;
+    bool displacementMapSet_;
+
+    // Stencil decal texture
+    std::string stencilDecalTexture_;
+    bool stencilDecalTextureSet_;
 };
 
 }   // namespace Meshborn

--- a/src/Material.h
+++ b/src/Material.h
@@ -41,6 +41,9 @@ class Material {
     void SetIlluminationModel(int model);
     bool GetIlluminationModel(int *model);
 
+    void SetOpticalDensity(float density);
+    bool GetOpticalDensity(float *density);
+
  private:
     std::string name_;
 
@@ -63,6 +66,10 @@ class Material {
     // Illumination model
     int illuminationModel_;
     bool illuminationModelSet_;
+
+    // Optical density
+    float opticalDensity_;
+    bool opticalDensitySet_;
 };
 
 }   // namespace Meshborn

--- a/src/Material.h
+++ b/src/Material.h
@@ -44,6 +44,9 @@ class Material {
     void SetOpticalDensity(float density);
     bool GetOpticalDensity(float *density);
 
+    void SetTransparentDissolve(float transparency);
+    bool GetTransparentDissolve(float *transparency);
+
  private:
     std::string name_;
 
@@ -70,6 +73,10 @@ class Material {
     // Optical density
     float opticalDensity_;
     bool opticalDensitySet_;
+
+    // Transparent dissolve
+    float transparentDissolve_;
+    bool transparentDissolveSet_;
 };
 
 }   // namespace Meshborn

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -60,7 +60,7 @@ class Vertex {
 #include "Logger.h"
 
 class ConsoleLogger: public Meshborn::Logger::ILogger {
-public:
+ public:
     ConsoleLogger() = default;
 
     void Log(Meshborn::Logger::LogLevel level,
@@ -72,7 +72,6 @@ public:
 
 
 int main(int argc, char** argv) {
-
     std::string filename;
 
     for (int i = 1; i < argc; ++i) {

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -1,0 +1,18 @@
+/*
+Meshborn
+Copyright (C) 2025  SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "BaseWavefrontParser.h"

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -83,5 +83,18 @@ bool BaseWavefrontParser::ParseFloat(const char* str, float *out) {
     return true;
 }
 
+bool BaseWavefrontParser::ParseInt(const char* str, int* out) {
+    errno = 0;
+    char* end;
+    long value = strtol(str, &end, 10); // base 10 for decimal
+
+    if (errno == ERANGE || *end != '\0' || value < INT_MIN || value > INT_MAX) {
+        return false;
+    }
+
+    *out = static_cast<int>(value);
+    return true;
+}
+
 }   // namespace WaveFront
 }   // namespace Meshborn

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -66,7 +66,8 @@ std::vector<std::string> BaseWavefrontParser::ReadFile(
 bool BaseWavefrontParser::StartsWith(const std::string& line,
                                      const std::string& prefix) {
     size_t i = 0;
-    while (i < line.size() && std::isspace(static_cast<unsigned char>(line[i]))) {
+    while (i < line.size() &&
+           std::isspace(static_cast<unsigned char>(line[i]))) {
         ++i;
     }
     return line.compare(i, prefix.length(), prefix) == 0;

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -23,7 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Meshborn {
 namespace WaveFront {
 
-std::vector<std::string> SplitElementString(const std::string& str) {
+std::vector<std::string> BaseWebfrontParser::SplitElementString(
+    const std::string& str) {
     std::vector<std::string> tokens;
     std::istringstream iss(str);
     std::string token;
@@ -35,7 +36,7 @@ std::vector<std::string> SplitElementString(const std::string& str) {
     return tokens;
 }
 
-std::vector<std::string> ReadObjFile(const std::string& filename) {
+std::vector<std::string> BaseWebfrontParser::ReadFile(const std::string& filename) {
     std::vector<std::string> lines;
     std::ifstream file(filename);
 

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Meshborn {
 namespace WaveFront {
 
-std::vector<std::string> BaseWebfrontParser::SplitElementString(
+std::vector<std::string> BaseWavefrontParser::SplitElementString(
     const std::string& str) {
     std::vector<std::string> tokens;
     std::istringstream iss(str);
@@ -36,7 +36,7 @@ std::vector<std::string> BaseWebfrontParser::SplitElementString(
     return tokens;
 }
 
-std::vector<std::string> BaseWebfrontParser::ReadFile(const std::string& filename) {
+std::vector<std::string> BaseWavefrontParser::ReadFile(const std::string& filename) {
     std::vector<std::string> lines;
     std::ifstream file(filename);
 

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -72,5 +72,15 @@ bool BaseWavefrontParser::StartsWith(const std::string& line,
     return line.compare(i, prefix.length(), prefix) == 0;
 }
 
+
+bool BaseWavefrontParser::ParseFloat(const char* str, float& out) {
+    errno = 0;
+    char* end;
+    float value = strtof(str, &end);
+    if (errno == ERANGE || *end != '\0') return false;
+    out = value;
+    return true;
+}
+
 }   // namespace WaveFront
 }   // namespace Meshborn

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -73,7 +73,6 @@ bool BaseWavefrontParser::StartsWith(const std::string& line,
     return line.compare(i, prefix.length(), prefix) == 0;
 }
 
-
 bool BaseWavefrontParser::ParseFloat(const char* str, float *out) {
     errno = 0;
     char* end;
@@ -86,7 +85,9 @@ bool BaseWavefrontParser::ParseFloat(const char* str, float *out) {
 bool BaseWavefrontParser::ParseInt(const char* str, int* out) {
     errno = 0;
     char* end;
-    long value = strtol(str, &end, 10); // base 10 for decimal
+
+    // Base 10 for decimal
+    int64_t value = std::strtoll(str, &end, 10);
 
     if (errno == ERANGE || *end != '\0' || value < INT_MIN || value > INT_MAX) {
         return false;

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -36,7 +36,8 @@ std::vector<std::string> BaseWavefrontParser::SplitElementString(
     return tokens;
 }
 
-std::vector<std::string> BaseWavefrontParser::ReadFile(const std::string& filename) {
+std::vector<std::string> BaseWavefrontParser::ReadFile(
+    const std::string& filename) {
     std::vector<std::string> lines;
     std::ifstream file(filename);
 

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -15,4 +15,49 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <fstream>
+#include <sstream>
+#include <utility>
 #include "BaseWavefrontParser.h"
+
+namespace Meshborn {
+namespace WaveFront {
+
+std::vector<std::string> SplitElementString(const std::string& str) {
+    std::vector<std::string> tokens;
+    std::istringstream iss(str);
+    std::string token;
+
+    while (iss >> token) {
+        tokens.push_back(token);
+    }
+
+    return tokens;
+}
+
+std::vector<std::string> ReadObjFile(const std::string& filename) {
+    std::vector<std::string> lines;
+    std::ifstream file(filename);
+
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file: " + filename);
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        // Only keep the line if it's not empty or not a comment.
+        if (!line.empty() && !line.starts_with("#")) {
+            // Strip Windows carriage return
+            if (line.back() == '\r') {
+                line.pop_back();
+            }
+
+            lines.push_back(std::move(line));
+        }
+    }
+
+    return lines;
+}
+
+}   // namespace WaveFront
+}   // namespace Meshborn

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -15,8 +15,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <cctype>   // for std::isspace
 #include <fstream>
 #include <sstream>
+#include <string>
 #include <utility>
 #include "BaseWavefrontParser.h"
 
@@ -59,6 +61,15 @@ std::vector<std::string> BaseWavefrontParser::ReadFile(
     }
 
     return lines;
+}
+
+bool BaseWavefrontParser::StartsWith(const std::string& line,
+                                     const std::string& prefix) {
+    size_t i = 0;
+    while (i < line.size() && std::isspace(static_cast<unsigned char>(line[i]))) {
+        ++i;
+    }
+    return line.compare(i, prefix.length(), prefix) == 0;
 }
 
 }   // namespace WaveFront

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -74,12 +74,12 @@ bool BaseWavefrontParser::StartsWith(const std::string& line,
 }
 
 
-bool BaseWavefrontParser::ParseFloat(const char* str, float& out) {
+bool BaseWavefrontParser::ParseFloat(const char* str, float *out) {
     errno = 0;
     char* end;
     float value = strtof(str, &end);
     if (errno == ERANGE || *end != '\0') return false;
-    out = value;
+    *out = value;
     return true;
 }
 

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -1,0 +1,24 @@
+/*
+Meshborn
+Copyright (C) 2025  SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef WAVEFRONT_BASEWAVEFRONTPARSER_H_
+#define WAVEFRONT_BASEWAVEFRONTPARSER_H_
+
+class BaseWebfrontParser {
+};
+
+#endif  //  WAVEFRONT_BASEWAVEFRONTPARSER_H_

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -25,7 +25,7 @@ namespace WaveFront {
 
 class BaseWebfrontParser {
  protected:
-    std::vector<std::string> ReadObjFile(const std::string& filename);
+    std::vector<std::string> ReadFile(const std::string& filename);
 
     std::vector<std::string> SplitElementString(const std::string& str);
 };

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Meshborn {
 namespace WaveFront {
 
-class BaseWebfrontParser {
+class BaseWavefrontParser {
  protected:
     std::vector<std::string> ReadFile(const std::string& filename);
 

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -28,6 +28,8 @@ class BaseWavefrontParser {
     std::vector<std::string> ReadFile(const std::string& filename);
 
     std::vector<std::string> SplitElementString(const std::string& str);
+
+    bool StartsWith(const std::string& line, const std::string& prefix);
 };
 
 }   // namespace WaveFront

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -17,8 +17,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifndef WAVEFRONT_BASEWAVEFRONTPARSER_H_
 #define WAVEFRONT_BASEWAVEFRONTPARSER_H_
+#include <string>
+#include <vector>
+
+namespace Meshborn {
+namespace WaveFront {
 
 class BaseWebfrontParser {
+ protected:
+    std::vector<std::string> ReadObjFile(const std::string& filename);
+
+    std::vector<std::string> SplitElementString(const std::string& str);
 };
+
+}   // namespace WaveFront
+}   // namespace Meshborn
 
 #endif  //  WAVEFRONT_BASEWAVEFRONTPARSER_H_

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -30,6 +30,8 @@ class BaseWavefrontParser {
     std::vector<std::string> SplitElementString(const std::string& str);
 
     bool StartsWith(const std::string& line, const std::string& prefix);
+
+    bool ParseFloat(const char* str, float& out);
 };
 
 }   // namespace WaveFront

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -32,6 +32,8 @@ class BaseWavefrontParser {
     bool StartsWith(const std::string& line, const std::string& prefix);
 
     bool ParseFloat(const char* str, float *out);
+
+    bool ParseInt(const char* str, int *out);
 };
 
 }   // namespace WaveFront

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -31,7 +31,7 @@ class BaseWavefrontParser {
 
     bool StartsWith(const std::string& line, const std::string& prefix);
 
-    bool ParseFloat(const char* str, float& out);
+    bool ParseFloat(const char* str, float *out);
 };
 
 }   // namespace WaveFront

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -254,9 +254,9 @@ bool MaterialLibraryParser::ProcessTagAmbientColour(std::string_view line,
     float green;
     float blue;
 
-    if (!ParseFloat(words[1].c_str(), red)) return false;
-    if (!ParseFloat(words[2].c_str(), green)) return false;
-    if (!ParseFloat(words[3].c_str(), blue)) return false;
+    if (!ParseFloat(words[1].c_str(), &red)) return false;
+    if (!ParseFloat(words[2].c_str(), &green)) return false;
+    if (!ParseFloat(words[3].c_str(), &blue)) return false;
 
     *colour = glm::vec3(red, green, blue);
 
@@ -275,9 +275,9 @@ bool MaterialLibraryParser::ProcessTagDiffuseColour(std::string_view line,
     float green;
     float blue;
 
-    if (!ParseFloat(words[1].c_str(), red)) return false;
-    if (!ParseFloat(words[2].c_str(), green)) return false;
-    if (!ParseFloat(words[3].c_str(), blue)) return false;
+    if (!ParseFloat(words[1].c_str(), &red)) return false;
+    if (!ParseFloat(words[2].c_str(), &green)) return false;
+    if (!ParseFloat(words[3].c_str(), &blue)) return false;
 
     *colour = glm::vec3(red, green, blue);
 
@@ -296,9 +296,9 @@ bool MaterialLibraryParser::ProcessTagEmissiveColour(std::string_view line,
     float green;
     float blue;
 
-    if (!ParseFloat(words[1].c_str(), red)) return false;
-    if (!ParseFloat(words[2].c_str(), green)) return false;
-    if (!ParseFloat(words[3].c_str(), blue)) return false;
+    if (!ParseFloat(words[1].c_str(), &red)) return false;
+    if (!ParseFloat(words[2].c_str(), &green)) return false;
+    if (!ParseFloat(words[3].c_str(), &blue)) return false;
 
     *colour = glm::vec3(red, green, blue);
 
@@ -317,9 +317,9 @@ bool MaterialLibraryParser::ProcessTagSpecularColour(std::string_view line,
     float green;
     float blue;
 
-    if (!ParseFloat(words[1].c_str(), red)) return false;
-    if (!ParseFloat(words[2].c_str(), green)) return false;
-    if (!ParseFloat(words[3].c_str(), blue)) return false;
+    if (!ParseFloat(words[1].c_str(), &red)) return false;
+    if (!ParseFloat(words[2].c_str(), &green)) return false;
+    if (!ParseFloat(words[3].c_str(), &blue)) return false;
 
     *colour = glm::vec3(red, green, blue);
 

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -536,5 +536,37 @@ bool MaterialLibraryParser::ProcessTagIlluminationModel(std::string_view line,
     return true;
 }
 
+bool MaterialLibraryParser::ProcessTagAmbientTextureMap(std::string_view line,
+                                                        std::string *map) {
+}
+
+bool MaterialLibraryParser::ProcessTagDiffuseTextureMap(std::string_view line,
+                                                        std::string *map) {
+}
+
+bool MaterialLibraryParser::ProcessTagSpecularColorTextureMap(
+    std::string_view line, std::string *map) {
+}
+
+bool MaterialLibraryParser::ProcessTagSpecularHighlightConponent(
+    std::string_view line, std::string *component) {
+}
+
+bool MaterialLibraryParser::ProcessTagAlphaåTextureMap(std::string_view line,
+                                                       std::string *map) {
+}
+
+bool MaterialLibraryParser::ProcessTagBumpMap(std::string_view line,
+                                              std::string *map) {
+}
+
+bool MaterialLibraryParser::ProcessTagDisplacementMap(std::string_view line,
+                                                      std::string *map) {
+}
+
+bool MaterialLibraryParser::ProcessTagStencilDecalTexture(std::string_view line,
+                                                          std::string *texture) {
+}
+
 }   // namespace WaveFront
 }   // namespace Meshborn

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -78,7 +78,67 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
 
     for (const auto& line : rawLines) {
         std::string_view view(line);
-        std::cout << "[MATLIB] " << view << std::endl;
+
+        // New material
+        if (StartsWith(std::string(view), KEYWORD_NEW_MATERIAL)) {
+            std::cout << "New Material: " << view << std::endl;
+
+        // Ambient colour
+        } else if (StartsWith(std::string(view), KEYWORD_AMBIENT)) {
+            std::cout << "Ambient colour: " << view << std::endl;
+            //  auto a = SplitElementString(std::string(view));
+            //  printf("=> Count : %d\n", a.size());
+
+        // Diffuse colour
+        } else if (StartsWith(std::string(view), KEYWORD_DIFFUSE)) {
+            std::cout << "Diffuse colour: " << view << std::endl;
+
+        // Emissive colour
+        } else if (StartsWith(std::string(view), KEYWORD_EMISSIVE)) {
+            std::cout << "Emissive colour: " << view << std::endl;
+
+        // Specular colour
+        } else if (StartsWith(std::string(view), KEYWORD_SPECULAR)) {
+            std::cout << "Specular colour: " << view << std::endl;
+
+        // Specular exponent
+        } else if (StartsWith(std::string(view), KEYWORD_SPECULAR_EXPONENT)) {
+            std::cout << "Specular exponent: " << view << std::endl;
+
+        // Transparent dissolve
+        } else if (StartsWith(std::string(view), KEYWORD_TRANSPARENT_DISOLVE)) {
+            std::cout << "Transparent dissolve: " << view << std::endl;
+
+        // Optical density
+        } else if (StartsWith(std::string(view), KEYWORD_OPTICAL_DENSITY)) {
+            std::cout << "Optical density: " << view << std::endl;
+
+        // Illumination model
+        } else if (StartsWith(std::string(view), KEYWORD_ILLUMINATION_MODEL)) {
+            std::cout << "Illumination model: " << view << std::endl;
+        }
+
+        else {
+            std::cout << "Unknown: " << view << std::endl;
+        }
+
+        /*
+const char KEYWORD_AMBIENT_TEXTURE_MAP[] = "map_Ka ";
+const char KEYWORD_DIFFUSE_TEXTURE_MAP[] = "map_Kd ";
+const char KEYWORD_SPECULAR_COLOR_TEXTURE_MAP[] = "map_Ks ";
+const char KEYWORD_SPECULAR_HIGHLIGHT_COMPONENT[] = "map_Ns ";
+const char KEYWORD_ALPHA_TEXTURE_MAP[] = "map_d ";
+
+// map_bump and bump are one and the same.
+const char KEYWORD_MAP_BUMP[] = "map_bump ";
+const char KEYWORD_BUMP_MAP[] = "bump ";
+
+const char KEYWORD_DISPLACEMENT_MAP[] = "disp ";
+
+// defaults to 'matte' channel of the image)
+const char KEYWORD_STENCIL_DECAL_TEXTURE[] = "decal ";
+
+        */
     }
 }
 

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <iostream> // TEMP
+#include <vector>
 #include "MaterialLibraryParser.h"
 
 namespace Meshborn {
@@ -79,7 +80,6 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
         std::string_view view(line);
         std::cout << "[MATLIB] " << view << std::endl;
     }
-
 }
 
 }   // namespace WaveFront

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -108,7 +108,7 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
             }
 
             glm::vec3 ambientColour;
-            if (!ProcessTagAmbientColour(view, ambientColour)) {
+            if (!ProcessTagAmbientColour(view, &ambientColour)) {
                 return;
             }
 
@@ -127,7 +127,7 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
             }
 
             glm::vec3 diffuseColour;
-            if (!ProcessTagDiffuseColour(view, diffuseColour)) {
+            if (!ProcessTagDiffuseColour(view, &diffuseColour)) {
                 return;
             }
 
@@ -150,7 +150,7 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
             }
 
             glm::vec3 specularColour;
-            if (!ProcessTagSpecularColour(view, specularColour)) {
+            if (!ProcessTagSpecularColour(view, &specularColour)) {
                 return;
             }
 
@@ -243,7 +243,7 @@ bool MaterialLibraryParser::ProcessTagNewMaterial(std::string_view line,
 }
 
 bool MaterialLibraryParser::ProcessTagAmbientColour(std::string_view line,
-                                                    glm::vec3 &colour) {
+                                                    glm::vec3 *colour) {
     auto words = SplitElementString(std::string(line));
 
     if (words.size() != 4) {
@@ -258,13 +258,13 @@ bool MaterialLibraryParser::ProcessTagAmbientColour(std::string_view line,
     if (!ParseFloat(words[2].c_str(), green)) return false;
     if (!ParseFloat(words[3].c_str(), blue)) return false;
 
-    colour = glm::vec3(red, green, blue);
+    *colour = glm::vec3(red, green, blue);
 
     return true;
 }
 
 bool MaterialLibraryParser::ProcessTagDiffuseColour(std::string_view line,
-                                                    glm::vec3 &colour) {
+                                                    glm::vec3 *colour) {
     auto words = SplitElementString(std::string(line));
 
     if (words.size() != 4) {
@@ -279,13 +279,13 @@ bool MaterialLibraryParser::ProcessTagDiffuseColour(std::string_view line,
     if (!ParseFloat(words[2].c_str(), green)) return false;
     if (!ParseFloat(words[3].c_str(), blue)) return false;
 
-    colour = glm::vec3(red, green, blue);
+    *colour = glm::vec3(red, green, blue);
 
     return true;
 }
 
 bool MaterialLibraryParser::ProcessTagEmissiveColour(std::string_view line,
-                                                     glm::vec3 &colour) {
+                                                     glm::vec3 *colour) {
     auto words = SplitElementString(std::string(line));
 
     if (words.size() != 4) {
@@ -300,13 +300,13 @@ bool MaterialLibraryParser::ProcessTagEmissiveColour(std::string_view line,
     if (!ParseFloat(words[2].c_str(), green)) return false;
     if (!ParseFloat(words[3].c_str(), blue)) return false;
 
-    colour = glm::vec3(red, green, blue);
+    *colour = glm::vec3(red, green, blue);
 
     return true;
 }
 
 bool MaterialLibraryParser::ProcessTagSpecularColour(std::string_view line,
-                                                     glm::vec3 &colour) {
+                                                     glm::vec3 *colour) {
     auto words = SplitElementString(std::string(line));
 
     if (words.size() != 4) {
@@ -321,7 +321,7 @@ bool MaterialLibraryParser::ProcessTagSpecularColour(std::string_view line,
     if (!ParseFloat(words[2].c_str(), green)) return false;
     if (!ParseFloat(words[3].c_str(), blue)) return false;
 
-    colour = glm::vec3(red, green, blue);
+    *colour = glm::vec3(red, green, blue);
 
     return true;
 }

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -177,7 +177,8 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
                 return;
             }
 
-            materials[currentMaterial].SetTransparentDissolve(transparentDissolve);
+            materials[currentMaterial].SetTransparentDissolve(
+                transparentDissolve);
             float transparency;
             materials[currentMaterial].GetTransparentDissolve(&transparency);
             LOG(Logger::LogLevel::Debug, std::format(
@@ -428,7 +429,8 @@ bool MaterialLibraryParser::ProcessTagSpecularExponent(std::string_view line,
  * Valid values range from 0.0 to 1.0.
  *
  * @param line The input line containing the transparency value.
- * @param transparency Pointer to a float where the parsed value will be stored.
+ * @param transparency Pointer to a float where the parsed value will be
+ *                     stored.
  * @return true if parsing and validation succeed, false otherwise.
  */
 bool MaterialLibraryParser::ProcessTagTransparentDissolve(std::string_view line,
@@ -436,7 +438,8 @@ bool MaterialLibraryParser::ProcessTagTransparentDissolve(std::string_view line,
     auto words = SplitElementString(std::string(line));
 
     if (words.size() != 2) {
-        LOG(Logger::LogLevel::Critical, "Material transparent dissolve invalid");
+        LOG(Logger::LogLevel::Critical,
+            "Material transparent dissolve invalid");
         return false;
     }
 
@@ -538,34 +541,122 @@ bool MaterialLibraryParser::ProcessTagIlluminationModel(std::string_view line,
 
 bool MaterialLibraryParser::ProcessTagAmbientTextureMap(std::string_view line,
                                                         std::string *map) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Ambient texture map is invalid: '{}'", line));
+        return false;
+    }
+
+    *map = words[1];
+
+    return true;
 }
 
 bool MaterialLibraryParser::ProcessTagDiffuseTextureMap(std::string_view line,
                                                         std::string *map) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Diffuse texture map is invalid: '{}'", line));
+        return false;
+    }
+
+    *map = words[1];
+
+    return true;
 }
 
 bool MaterialLibraryParser::ProcessTagSpecularColorTextureMap(
     std::string_view line, std::string *map) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Specular texture map is invalid: '{}'", line));
+        return false;
+    }
+
+    *map = words[1];
+
+    return true;
 }
 
 bool MaterialLibraryParser::ProcessTagSpecularHighlightConponent(
     std::string_view line, std::string *component) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Specular highlight conponent is invalid: '{}'", line));
+        return false;
+    }
+
+    *component = words[1];
+
+    return true;
 }
 
-bool MaterialLibraryParser::ProcessTagAlphaåTextureMap(std::string_view line,
+bool MaterialLibraryParser::ProcessTagAlphaTextureMap(std::string_view line,
                                                        std::string *map) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Alpha texture map is invalid: '{}'", line));
+        return false;
+    }
+
+    *map = words[1];
+
+    return true;
 }
 
 bool MaterialLibraryParser::ProcessTagBumpMap(std::string_view line,
                                               std::string *map) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Bump map is invalid: '{}'", line));
+        return false;
+    }
+
+    *map = words[1];
+
+    return true;
 }
 
 bool MaterialLibraryParser::ProcessTagDisplacementMap(std::string_view line,
                                                       std::string *map) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Displacement map is invalid: '{}'", line));
+        return false;
+    }
+
+    *map = words[1];
+
+    return true;
 }
 
-bool MaterialLibraryParser::ProcessTagStencilDecalTexture(std::string_view line,
-                                                          std::string *texture) {
+bool MaterialLibraryParser::ProcessTagStencilDecalTexture(
+    std::string_view line, std::string *texture) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Stencil decal texture is invalid: '{}'", line));
+        return false;
+    }
+
+    *texture = words[1];
+
+    return true;
 }
 
 }   // namespace WaveFront

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -227,6 +227,13 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
     }
 }
 
+/**
+ * @brief Parses a new material tag line and extracts the material name.
+ *
+ * @param line The input line containing the new material definition.
+ * @param material Reference to a string to store the parsed material name.
+ * @return true if parsing was successful, false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagNewMaterial(std::string_view line,
                                                   std::string &material) {
     auto words = SplitElementString(std::string(line));
@@ -242,6 +249,13 @@ bool MaterialLibraryParser::ProcessTagNewMaterial(std::string_view line,
     return true;
 }
 
+/**
+ * @brief Parses an ambient colour tag line and extracts the RGB values.
+ *
+ * @param line The input line containing the ambient colour definition.
+ * @param colour Pointer to glm::vec3 to store the parsed RGB values.
+ * @return true if parsing was successful, false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagAmbientColour(std::string_view line,
                                                     glm::vec3 *colour) {
     auto words = SplitElementString(std::string(line));
@@ -263,6 +277,13 @@ bool MaterialLibraryParser::ProcessTagAmbientColour(std::string_view line,
     return true;
 }
 
+/**
+ * @brief Parses a diffuse colour tag line and extracts the RGB values.
+ *
+ * @param line The input line containing the diffuse colour definition.
+ * @param colour Pointer to glm::vec3 to store the parsed RGB values.
+ * @return true if parsing was successful, false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagDiffuseColour(std::string_view line,
                                                     glm::vec3 *colour) {
     auto words = SplitElementString(std::string(line));
@@ -284,6 +305,13 @@ bool MaterialLibraryParser::ProcessTagDiffuseColour(std::string_view line,
     return true;
 }
 
+/**
+ * @brief Parses an emissive colour tag line and extracts the RGB values.
+ *
+ * @param line The input line containing the emissive colour definition.
+ * @param colour Pointer to glm::vec3 to store the parsed RGB values.
+ * @return true if parsing was successful, false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagEmissiveColour(std::string_view line,
                                                      glm::vec3 *colour) {
     auto words = SplitElementString(std::string(line));
@@ -305,6 +333,13 @@ bool MaterialLibraryParser::ProcessTagEmissiveColour(std::string_view line,
     return true;
 }
 
+/**
+ * @brief Parses a specular colour tag line and extracts the RGB values.
+ *
+ * @param line The input line containing the specular colour definition.
+ * @param colour Pointer to glm::vec3 to store the parsed RGB values.
+ * @return true if parsing was successful, false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagSpecularColour(std::string_view line,
                                                      glm::vec3 *colour) {
     auto words = SplitElementString(std::string(line));

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -116,29 +116,54 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
         // Illumination model
         } else if (StartsWith(std::string(view), KEYWORD_ILLUMINATION_MODEL)) {
             std::cout << "Illumination model: " << view << std::endl;
-        }
 
-        else {
+        // Ambient texture map
+        } else if (StartsWith(std::string(view),
+                              KEYWORD_AMBIENT_TEXTURE_MAP)) {
+            std::cout << "Ambient texture map: " << view << std::endl;
+
+        // Diffuse texture map
+        } else if (StartsWith(std::string(view),
+                              KEYWORD_DIFFUSE_TEXTURE_MAP)) {
+            std::cout << "Diffuse texture map: " << view << std::endl;
+
+        // Specular color texture map
+        } else if (StartsWith(std::string(view),
+                              KEYWORD_SPECULAR_COLOR_TEXTURE_MAP)) {
+            std::cout << "Specular color texture map: " << view << std::endl;
+
+        // Specular highlight component
+        } else if (StartsWith(std::string(view),
+                              KEYWORD_SPECULAR_HIGHLIGHT_COMPONENT)) {
+            std::cout << "Specular highlight component: " << view << std::endl;
+
+        // Alpha texture map
+        } else if (StartsWith(std::string(view),
+                              KEYWORD_ALPHA_TEXTURE_MAP)) {
+            std::cout << "Alpha texture map: " << view << std::endl;
+
+        // Bump map
+        } else if ((StartsWith(std::string(view),
+                               KEYWORD_MAP_BUMP)) ||
+                   (StartsWith(std::string(view),
+                               KEYWORD_BUMP_MAP))) {
+            std::cout << "Bump map: " << view << std::endl;
+
+        // Displacement map
+        } else if (StartsWith(std::string(view),
+                              KEYWORD_DISPLACEMENT_MAP)) {
+        std::cout << "Displacement map: " << view << std::endl;
+
+       // Stencil decal texture
+        } else if (StartsWith(std::string(view),
+                              KEYWORD_STENCIL_DECAL_TEXTURE)) {
+            std::cout << "Stencil decal texture: " << view << std::endl;
+
+        // Unknown tag : Doesn't mean it's invalid, it could be a tag that
+        //               currently isn't parsed.
+        } else {
             std::cout << "Unknown: " << view << std::endl;
         }
-
-        /*
-const char KEYWORD_AMBIENT_TEXTURE_MAP[] = "map_Ka ";
-const char KEYWORD_DIFFUSE_TEXTURE_MAP[] = "map_Kd ";
-const char KEYWORD_SPECULAR_COLOR_TEXTURE_MAP[] = "map_Ks ";
-const char KEYWORD_SPECULAR_HIGHLIGHT_COMPONENT[] = "map_Ns ";
-const char KEYWORD_ALPHA_TEXTURE_MAP[] = "map_d ";
-
-// map_bump and bump are one and the same.
-const char KEYWORD_MAP_BUMP[] = "map_bump ";
-const char KEYWORD_BUMP_MAP[] = "bump ";
-
-const char KEYWORD_DISPLACEMENT_MAP[] = "disp ";
-
-// defaults to 'matte' channel of the image)
-const char KEYWORD_STENCIL_DECAL_TEXTURE[] = "decal ";
-
-        */
     }
 }
 

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -49,22 +49,6 @@ const char KEYWORD_DISPLACEMENT_MAP[] = "disp ";
 // defaults to 'matte' channel of the image)
 const char KEYWORD_STENCIL_DECAL_TEXTURE[] = "decal ";
 
-/*
-Illumination model (illum tag)
-illum	Description
-0	Color on, ambient off
-1	Color on, ambient on
-2	Highlight on
-3	Reflection on and ray trace on
-4	Transparency: Glass on, Reflection: Ray trace on
-5	Reflection: Fresnel on and ray trace on
-6	Transparency: Refraction on, Reflection: Fresnel off and ray trace on
-7	Transparency: Refraction on, Reflection: Fresnel on and ray trace on
-8	Reflection on and ray trace off
-9	Transparency: Glass on, Reflection: Ray trace off
-10	Casts shadows onto invisible surfaces
-*/
-
 MaterialLibraryParser::MaterialLibraryParser() {
 }
 
@@ -428,6 +412,25 @@ bool MaterialLibraryParser::ProcessTagTransparentDissolve(std::string_view line,
                                                           float *transparency) {
 }
 
+/**
+ * @brief Parses the optical density (index of refraction) from a line.
+ *
+ * This function extracts the optical density value (Ni) from a given line
+ * and stores it in the provided `density` pointer. Optical density affects
+ * how much light bends as it enters a material, commonly used for transparent
+ * materials like glass or water.
+ *
+ * Valid values range from 0.001 to 10.0. Typical real-world values fall
+ * between 1.0 and 2.0. Examples include:
+ *   - Air: 1.0
+ *   - Water: 1.33
+ *   - Glass: 1.5
+ *   - Diamond: 2.42
+ *
+ * @param line The input line containing the optical density value.
+ * @param density Pointer to a float where the parsed value will be stored.
+ * @return true if parsing and validation succeed, false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagOpticalDensity(std::string_view line,
                                                      float *density) {
     auto words = SplitElementString(std::string(line));
@@ -448,6 +451,32 @@ bool MaterialLibraryParser::ProcessTagOpticalDensity(std::string_view line,
     return true;
 }
 
+/*
+ * Parses the illumination model from a line in a material library file.
+ *
+ * The "illum" tag specifies how the surface is illuminated. The model is
+ * defined by an integer value ranging from 0 to 10, each representing a
+ * specific shading/lighting mode:
+ *
+ *   0  - Color on, ambient off
+ *   1  - Color on, ambient on
+ *   2  - Highlight on
+ *   3  - Reflection on and ray trace on
+ *   4  - Transparency: Glass on, Reflection: Ray trace on
+ *   5  - Reflection: Fresnel on and ray trace on
+ *   6  - Transparency: Refraction on, Reflection: Fresnel off and ray trace on
+ *   7  - Transparency: Refraction on, Reflection: Fresnel on and ray trace on
+ *   8  - Reflection on and ray trace off
+ *   9  - Transparency: Glass on, Reflection: Ray trace off
+ *  10  - Casts shadows onto invisible surfaces
+ *
+ * Parameters:
+ *   line    - The input line containing the "illum" tag and its value.
+ *   density - Pointer to store the parsed illumination model index.
+ *
+ * Returns:
+ *   true if the illumination model is parsed and valid; false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagIlluminationModel(std::string_view line,
                                                         int *density) {
     auto words = SplitElementString(std::string(line));

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -20,6 +20,47 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Meshborn {
 namespace WaveFront {
 
+const char KEYWORD_NEW_MATERIAL[] = "newmtl ";
+const char KEYWORD_AMBIENT[] = "Ka ";
+const char KEYWORD_DIFFUSE[] = "Kd ";
+const char KEYWORD_EMISSIVE[] = "Ke ";
+const char KEYWORD_SPECULAR[] = "Ks ";
+const char KEYWORD_SPECULAR_EXPONENT[] = "Ns ";
+const char KEYWORD_TRANSPARENT_DISOLVE[] = "d ";
+const char KEYWORD_OPTICAL_DENSITY[] = "Ni ";
+const char KEYWORD_ILLUMINATION_MODEL[] = "illum ";
+
+const char KEYWORD_AMBIENT_TEXTURE_MAP[] = "map_Ka ";
+const char KEYWORD_DIFFUSE_TEXTURE_MAP[] = "map_Kd ";
+const char KEYWORD_SPECULAR_COLOR_TEXTURE_MAP[] = "map_Ks ";
+const char KEYWORD_SPECULAR_HIGHLIGHT_COMPONENT[] = "map_Ns ";
+const char KEYWORD_ALPHA_TEXTURE_MAP[] = "map_d ";
+
+// map_bump and bump are one and the same.
+const char KEYWORD_MAP_BUMP[] = "map_bump ";
+const char KEYWORD_BUMP_MAP[] = "bump ";
+
+const char KEYWORD_DISPLACEMENT_MAP[] = "disp ";
+
+// defaults to 'matte' channel of the image)
+const char KEYWORD_STENCIL_DECAL_TEXTURE[] = "decal ";
+
+/*
+Illumination model (illum tag)
+illum	Description
+0	Color on, ambient off
+1	Color on, ambient on
+2	Highlight on
+3	Reflection on and ray trace on
+4	Transparency: Glass on, Reflection: Ray trace on
+5	Reflection: Fresnel on and ray trace on
+6	Transparency: Refraction on, Reflection: Fresnel off and ray trace on
+7	Transparency: Refraction on, Reflection: Fresnel on and ray trace on
+8	Reflection on and ray trace off
+9	Transparency: Glass on, Reflection: Ray trace off
+10	Casts shadows onto invisible surfaces
+*/
+
 MaterialLibraryParser::MaterialLibraryParser() {
 }
 

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -72,12 +72,12 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
         if (StartsWith(std::string(view), KEYWORD_NEW_MATERIAL)) {
             std::string materialName;
 
-            if (!ProcessTagNewMaterial(view, materialName)) {
+            if (!ProcessTagNewMaterial(view, &materialName)) {
                 return;
             }
 
             LOG(Logger::LogLevel::Debug, std::format(
-                "New Material => {}", materialName));
+                "NEW MATERIAL => {}", materialName));
 
             Material newMaterial(materialName);
             materials.push_back(newMaterial);
@@ -221,49 +221,167 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
         // Ambient texture map
         } else if (StartsWith(std::string(view),
                               KEYWORD_AMBIENT_TEXTURE_MAP)) {
-            std::cout << "Ambient texture map: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'map_Ka' keyword");
+                return;
+            }
+
+            std::string ambientTextureMap;
+            if (!ProcessTagAmbientTextureMap(line, &ambientTextureMap)) {
+                return;
+            }
+
+            materials[currentMaterial].SetAmbientTextureMap(ambientTextureMap);
+            std::string textureMap;
+            materials[currentMaterial].GetAmbientTextureMap(&textureMap);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|AMBIENT TEXTURE MAP => {}", textureMap));
 
         // Diffuse texture map
         } else if (StartsWith(std::string(view),
                               KEYWORD_DIFFUSE_TEXTURE_MAP)) {
-            std::cout << "Diffuse texture map: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'map_Kd' keyword");
+                return;
+            }
+
+            std::string diffuseTextureMap;
+            if (!ProcessTagDiffuseTextureMap(line, &diffuseTextureMap)) {
+                return;
+            }
+
+            materials[currentMaterial].SetDiffuseTextureMap(diffuseTextureMap);
+            std::string textureMap;
+            materials[currentMaterial].GetDiffuseTextureMap(&textureMap);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|DIFFUSE TEXTURE MAP => {}", textureMap));
 
         // Specular color texture map
         } else if (StartsWith(std::string(view),
                               KEYWORD_SPECULAR_COLOR_TEXTURE_MAP)) {
-            std::cout << "Specular color texture map: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'map_Ks' keyword");
+                return;
+            }
+
+            std::string colourTextureMap;
+            if (!ProcessTagSpecularColorTextureMap(line, &colourTextureMap)) {
+                return;
+            }
+
+            materials[currentMaterial].SetSpecularColourTextureMap(
+                colourTextureMap);
+            std::string textureMap;
+            materials[currentMaterial].GetSpecularColourTextureMap(&textureMap);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|SPECULAR COLOUR TEXTURE MAP => {}", textureMap));
 
         // Specular highlight component
         } else if (StartsWith(std::string(view),
                               KEYWORD_SPECULAR_HIGHLIGHT_COMPONENT)) {
-            std::cout << "Specular highlight component: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'map_Ns' keyword");
+                return;
+            }
+
+            std::string highlightComponent;
+            if (!ProcessTagSpecularHighlightConponent(line,
+                                                       &highlightComponent)) {
+                return;
+            }
+
+            materials[currentMaterial].SetSpecularHighlightComponent(
+                highlightComponent);
+            std::string component;
+            materials[currentMaterial].GetSpecularHighlightComponent(
+                &component);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|SPECULAR HIGHLIGHT COMPONENT => {}", component));
 
         // Alpha texture map
         } else if (StartsWith(std::string(view),
                               KEYWORD_ALPHA_TEXTURE_MAP)) {
-            std::cout << "Alpha texture map: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'map_d' keyword");
+                return;
+            }
+
+            std::string alphaTextureMap;
+            if (!ProcessTagAlphaTextureMap(line, &alphaTextureMap)) {
+                return;
+            }
+
+            materials[currentMaterial].SetAlphaTextureMap(alphaTextureMap);
+            std::string textureMap;
+            materials[currentMaterial].GetAlphaTextureMap(&textureMap);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|ALPHA TEXTURE MAP => {}", textureMap));
 
         // Bump map
         } else if ((StartsWith(std::string(view),
                                KEYWORD_MAP_BUMP)) ||
                    (StartsWith(std::string(view),
                                KEYWORD_BUMP_MAP))) {
-            std::cout << "Bump map: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical,
+                    "Mis-ordered 'bump/map_bump' keyword");
+                return;
+            }
+
+            std::string bumpMap;
+            if (!ProcessTagBumpMap(line, &bumpMap)) {
+                return;
+            }
+
+            materials[currentMaterial].SetBumpMap(bumpMap);
+            std::string textureMap;
+            materials[currentMaterial].GetBumpMap(&textureMap);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|BUMP MAP => {}", textureMap));
 
         // Displacement map
         } else if (StartsWith(std::string(view),
                               KEYWORD_DISPLACEMENT_MAP)) {
-        std::cout << "Displacement map: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'disp' keyword");
+                return;
+            }
+
+            std::string displacementMap;
+            if (!ProcessTagDisplacementMap(line, &displacementMap)) {
+                return;
+            }
+
+            materials[currentMaterial].SetDisplacementMap(displacementMap);
+            std::string map;
+            materials[currentMaterial].GetDisplacementMap(&map);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|DISPLACEMENT MAP => {}", map));
 
        // Stencil decal texture
         } else if (StartsWith(std::string(view),
                               KEYWORD_STENCIL_DECAL_TEXTURE)) {
-            std::cout << "Stencil decal texture: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'decal' keyword");
+                return;
+            }
+
+            std::string decalTexture;
+            if (!ProcessTagStencilDecalTexture(line, &decalTexture)) {
+                return;
+            }
+
+            materials[currentMaterial].SetStencilDecalTexture(decalTexture);
+            std::string texture;
+            materials[currentMaterial].GetStencilDecalTexture(&texture);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|STENCIL DECAL TEXTURE => {}", texture));
 
         // Unknown tag : Doesn't mean it's invalid, it could be a tag that
         //               currently isn't parsed.
         } else {
-            std::cout << "Unknown: " << view << std::endl;
+            LOG(Logger::LogLevel::Debug, std::format(
+                "Unknown material tag '{}'", view));
         }
     }
 }
@@ -276,7 +394,7 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
  * @return true if parsing was successful, false otherwise.
  */
 bool MaterialLibraryParser::ProcessTagNewMaterial(std::string_view line,
-                                                  std::string &material) {
+                                                  std::string *material) {
     auto words = SplitElementString(std::string(line));
 
     if (words.size() != 2) {
@@ -285,7 +403,7 @@ bool MaterialLibraryParser::ProcessTagNewMaterial(std::string_view line,
         return false;
     }
 
-    material = words[1];
+    *material = words[1];
 
     return true;
 }

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -15,7 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <iostream> // TEMP
+#include <iostream>     // TEMP
 #include <vector>
 #include "MaterialLibraryParser.h"
 

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -114,14 +114,29 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
 
             materials[currentMaterial].SetAmbientColour(ambientColour);
             glm::vec3 colour;
-            materials[currentMaterial].GetAmbientColour(colour);
+            materials[currentMaterial].GetAmbientColour(&colour);
             LOG(Logger::LogLevel::Debug, std::format(
                 "MATERIAL|AMBIENT COLOUR => R: {} G: {} B: {}",
                 colour.x, colour.y, colour.z));
 
         // Diffuse colour
         } else if (StartsWith(std::string(view), KEYWORD_DIFFUSE)) {
-            std::cout << "Diffuse colour: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'Kd' keyword");
+                return;
+            }
+
+            glm::vec3 diffuseColour;
+            if (!ProcessTagDiffuseColour(view, diffuseColour)) {
+                return;
+            }
+
+            materials[currentMaterial].SetDiffuseColour(diffuseColour);
+            glm::vec3 colour;
+            materials[currentMaterial].GetDiffuseColour(&colour);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|DIFFUSE COLOUR => R: {} G: {} B: {}",
+                colour.x, colour.y, colour.z));
 
         // Emissive colour
         } else if (StartsWith(std::string(view), KEYWORD_EMISSIVE)) {
@@ -129,7 +144,22 @@ void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
 
         // Specular colour
         } else if (StartsWith(std::string(view), KEYWORD_SPECULAR)) {
-            std::cout << "Specular colour: " << view << std::endl;
+            if (currentMaterial == -1) {
+                LOG(Logger::LogLevel::Critical, "Mis-ordered 'Ks' keyword");
+                return;
+            }
+
+            glm::vec3 specularColour;
+            if (!ProcessTagSpecularColour(view, specularColour)) {
+                return;
+            }
+
+            materials[currentMaterial].SetSpecularColour(specularColour);
+            glm::vec3 colour;
+            materials[currentMaterial].GetSpecularColour(&colour);
+            LOG(Logger::LogLevel::Debug, std::format(
+                "MATERIAL|SPECULAR COLOUR => R: {} G: {} B: {}",
+                colour.x, colour.y, colour.z));
 
         // Specular exponent
         } else if (StartsWith(std::string(view), KEYWORD_SPECULAR_EXPONENT)) {
@@ -234,15 +264,66 @@ bool MaterialLibraryParser::ProcessTagAmbientColour(std::string_view line,
 }
 
 bool MaterialLibraryParser::ProcessTagDiffuseColour(std::string_view line,
-                                                    std::string &material) {
+                                                    glm::vec3 &colour) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 4) {
+        return false;
+    }
+
+    float red;
+    float green;
+    float blue;
+
+    if (!ParseFloat(words[1].c_str(), red)) return false;
+    if (!ParseFloat(words[2].c_str(), green)) return false;
+    if (!ParseFloat(words[3].c_str(), blue)) return false;
+
+    colour = glm::vec3(red, green, blue);
+
+    return true;
 }
 
 bool MaterialLibraryParser::ProcessTagEmissiveColour(std::string_view line,
-                                                     std::string &material) {
+                                                     glm::vec3 &colour) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 4) {
+        return false;
+    }
+
+    float red;
+    float green;
+    float blue;
+
+    if (!ParseFloat(words[1].c_str(), red)) return false;
+    if (!ParseFloat(words[2].c_str(), green)) return false;
+    if (!ParseFloat(words[3].c_str(), blue)) return false;
+
+    colour = glm::vec3(red, green, blue);
+
+    return true;
 }
 
 bool MaterialLibraryParser::ProcessTagSpecularColour(std::string_view line,
-                                                     std::string &material) {
+                                                     glm::vec3 &colour) {
+    auto words = SplitElementString(std::string(line));
+
+    if (words.size() != 4) {
+        return false;
+    }
+
+    float red;
+    float green;
+    float blue;
+
+    if (!ParseFloat(words[1].c_str(), red)) return false;
+    if (!ParseFloat(words[2].c_str(), green)) return false;
+    if (!ParseFloat(words[3].c_str(), blue)) return false;
+
+    colour = glm::vec3(red, green, blue);
+
+    return true;
 }
 
 

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -15,6 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <iostream> // TEMP
 #include "MaterialLibraryParser.h"
 
 namespace Meshborn {
@@ -65,6 +66,20 @@ MaterialLibraryParser::MaterialLibraryParser() {
 }
 
 void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
+    std::vector<std::string> rawLines;
+
+    try {
+        rawLines = ReadFile(materialFile);
+    }
+    catch (std::runtime_error ex) {
+        throw std::runtime_error(ex.what());
+    }
+
+    for (const auto& line : rawLines) {
+        std::string_view view(line);
+        std::cout << "[MATLIB] " << view << std::endl;
+    }
+
 }
 
 }   // namespace WaveFront

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -1,0 +1,30 @@
+/*
+Meshborn
+Copyright (C) 2025  SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "MaterialLibraryParser.h"
+
+namespace Meshborn {
+namespace WaveFront {
+
+MaterialLibraryParser::MaterialLibraryParser() {
+}
+
+void MaterialLibraryParser::ParseLibrary(std::string materialFile) {
+}
+
+}   // namespace WaveFront
+}   // namespace Meshborn

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -19,11 +19,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define WAVEFRONT_MATERIALLIBRARYPARSER_H_
 #include <string>
 
+namespace Meshborn {
+namespace WaveFront {
+
 class MaterialLibraryParser {
  public:
     MaterialLibraryParser();
 
     void ParseLibrary(std::string materialFile);
 }
+
+
+}   // namespace WaveFront
+}   // namespace Meshborn
 
 #endif  // WAVEFRONT_MATERIALLIBRARYPARSER_H_

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef WAVEFRONT_MATERIALLIBRARYPARSER_H_
 #define WAVEFRONT_MATERIALLIBRARYPARSER_H_
 #include <string>
+#include "BaseWavefrontParser.h"
 
 namespace Meshborn {
 namespace WaveFront {
@@ -27,7 +28,7 @@ class MaterialLibraryParser {
     MaterialLibraryParser();
 
     void ParseLibrary(std::string materialFile);
-}
+};
 
 
 }   // namespace WaveFront

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -31,7 +31,7 @@ class MaterialLibraryParser : public BaseWavefrontParser {
     void ParseLibrary(std::string materialFile);
 
  private:
-    bool ProcessTagNewMaterial(std::string_view line, std::string &material);
+    bool ProcessTagNewMaterial(std::string_view line, std::string *material);
 
     bool ProcessTagAmbientColour(std::string_view line, glm::vec3 *colour);
     bool ProcessTagDiffuseColour(std::string_view line, glm::vec3 *colour);

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Meshborn {
 namespace WaveFront {
 
-class MaterialLibraryParser {
+class MaterialLibraryParser : public BaseWavefrontParser {
  public:
     MaterialLibraryParser();
 

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -17,12 +17,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifndef WAVEFRONT_MATERIALLIBRARYPARSER_H_
 #define WAVEFRONT_MATERIALLIBRARYPARSER_H_
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include "glm/glm.hpp"
 #include "BaseWavefrontParser.h"
+#include "Material.h"
 
 namespace Meshborn {
 namespace WaveFront {
+
+using MaterialMap = std::unordered_map<std::string, std::shared_ptr<Material>>;
+
 
 class MaterialLibraryParser : public BaseWavefrontParser {
  public:

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -30,7 +30,7 @@ class MaterialLibraryParser : public BaseWavefrontParser {
 
     void ParseLibrary(std::string materialFile);
 
-private:
+ private:
     bool ProcessTagNewMaterial(std::string_view line, std::string &material);
 
     bool ProcessTagAmbientColour(std::string_view line, glm::vec3 &colour);

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -34,9 +34,9 @@ private:
     bool ProcessTagNewMaterial(std::string_view line, std::string &material);
 
     bool ProcessTagAmbientColour(std::string_view line, glm::vec3 &colour);
-    bool ProcessTagDiffuseColour(std::string_view line, std::string &material);
-    bool ProcessTagEmissiveColour(std::string_view line, std::string &material);
-    bool ProcessTagSpecularColour(std::string_view line, std::string &material);
+    bool ProcessTagDiffuseColour(std::string_view line, glm::vec3 &colour);
+    bool ProcessTagEmissiveColour(std::string_view line, glm::vec3 &colour);
+    bool ProcessTagSpecularColour(std::string_view line, glm::vec3 &colour);
 };
 
 

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -56,7 +56,7 @@ class MaterialLibraryParser : public BaseWavefrontParser {
     bool ProcessTagSpecularHighlightConponent(std::string_view line,
                                               std::string *component);
 
-    bool ProcessTagAlphaåTextureMap(std::string_view line, std::string *map);
+    bool ProcessTagAlphaTextureMap(std::string_view line, std::string *map);
 
     bool ProcessTagBumpMap(std::string_view line, std::string *map);
 

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -45,6 +45,25 @@ class MaterialLibraryParser : public BaseWavefrontParser {
     bool ProcessTagOpticalDensity(std::string_view line, float *density);
 
     bool ProcessTagIlluminationModel(std::string_view line, int *density);
+
+    bool ProcessTagAmbientTextureMap(std::string_view line, std::string *map);
+
+    bool ProcessTagDiffuseTextureMap(std::string_view line, std::string *map);
+
+    bool ProcessTagSpecularColorTextureMap(std::string_view line,
+                                           std::string *map);
+
+    bool ProcessTagSpecularHighlightConponent(std::string_view line,
+                                              std::string *component);
+
+    bool ProcessTagAlphaåTextureMap(std::string_view line, std::string *map);
+
+    bool ProcessTagBumpMap(std::string_view line, std::string *map);
+
+    bool ProcessTagDisplacementMap(std::string_view line, std::string *map);
+
+    bool ProcessTagStencilDecalTexture(std::string_view line,
+                                       std::string *texture);
 };
 
 }   // namespace WaveFront

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -34,7 +34,7 @@ class MaterialLibraryParser : public BaseWavefrontParser {
  public:
     MaterialLibraryParser();
 
-    void ParseLibrary(std::string materialFile);
+    bool ParseLibrary(std::string materialFile, MaterialMap *materials);
 
  private:
     bool ProcessTagNewMaterial(std::string_view line, std::string *material);

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef WAVEFRONT_MATERIALLIBRARYPARSER_H_
 #define WAVEFRONT_MATERIALLIBRARYPARSER_H_
 #include <string>
+#include "glm/glm.hpp"
 #include "BaseWavefrontParser.h"
 
 namespace Meshborn {
@@ -28,6 +29,14 @@ class MaterialLibraryParser : public BaseWavefrontParser {
     MaterialLibraryParser();
 
     void ParseLibrary(std::string materialFile);
+
+private:
+    bool ProcessTagNewMaterial(std::string_view line, std::string &material);
+
+    bool ProcessTagAmbientColour(std::string_view line, glm::vec3 &colour);
+    bool ProcessTagDiffuseColour(std::string_view line, std::string &material);
+    bool ProcessTagEmissiveColour(std::string_view line, std::string &material);
+    bool ProcessTagSpecularColour(std::string_view line, std::string &material);
 };
 
 

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -40,7 +40,8 @@ class MaterialLibraryParser : public BaseWavefrontParser {
 
     bool ProcessTagSpecularExponent(std::string_view line, float *shininess);
 
-    bool ProcessTagTransparentDissolve(std::string_view line, float *transparency);
+    bool ProcessTagTransparentDissolve(std::string_view line,
+                                       float *transparency);
 
     bool ProcessTagOpticalDensity(std::string_view line, float *density);
 

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -33,10 +33,10 @@ class MaterialLibraryParser : public BaseWavefrontParser {
  private:
     bool ProcessTagNewMaterial(std::string_view line, std::string &material);
 
-    bool ProcessTagAmbientColour(std::string_view line, glm::vec3 &colour);
-    bool ProcessTagDiffuseColour(std::string_view line, glm::vec3 &colour);
-    bool ProcessTagEmissiveColour(std::string_view line, glm::vec3 &colour);
-    bool ProcessTagSpecularColour(std::string_view line, glm::vec3 &colour);
+    bool ProcessTagAmbientColour(std::string_view line, glm::vec3 *colour);
+    bool ProcessTagDiffuseColour(std::string_view line, glm::vec3 *colour);
+    bool ProcessTagEmissiveColour(std::string_view line, glm::vec3 *colour);
+    bool ProcessTagSpecularColour(std::string_view line, glm::vec3 *colour);
 };
 
 

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -1,0 +1,29 @@
+/*
+Meshborn
+Copyright (C) 2025  SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef WAVEFRONT_MATERIALLIBRARYPARSER_H_
+#define WAVEFRONT_MATERIALLIBRARYPARSER_H_
+#include <string>
+
+class MaterialLibraryParser {
+ public:
+    MaterialLibraryParser();
+
+    void ParseLibrary(std::string materialFile);
+}
+
+#endif  // WAVEFRONT_MATERIALLIBRARYPARSER_H_

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -37,8 +37,15 @@ class MaterialLibraryParser : public BaseWavefrontParser {
     bool ProcessTagDiffuseColour(std::string_view line, glm::vec3 *colour);
     bool ProcessTagEmissiveColour(std::string_view line, glm::vec3 *colour);
     bool ProcessTagSpecularColour(std::string_view line, glm::vec3 *colour);
-};
 
+    bool ProcessTagSpecularExponent(std::string_view line, float *shininess);
+
+    bool ProcessTagTransparentDissolve(std::string_view line, float *transparency);
+
+    bool ProcessTagOpticalDensity(std::string_view line, float *density);
+
+    bool ProcessTagIlluminationModel(std::string_view line, int *density);
+};
 
 }   // namespace WaveFront
 }   // namespace Meshborn

--- a/src/wavefront/WaveFrontObjLoader.cpp
+++ b/src/wavefront/WaveFrontObjLoader.cpp
@@ -262,7 +262,15 @@ bool ParseMaterials(std::string_view element, std::string &materialLibrary) {
         return false;
     }
 
-    materialLibrary = words[1];
+    std::ifstream file(words[1]);
+
+    if (!file.good()) {
+        LOG(Logger::LogLevel::Warning, std::format(
+            "Materials library '{}' is missing/inaccessible",
+            words[1]));
+    } else {
+        materialLibrary = words[1];
+    }
 
     return true;
 }

--- a/src/wavefront/WaveFrontObjLoader.cpp
+++ b/src/wavefront/WaveFrontObjLoader.cpp
@@ -358,7 +358,11 @@ bool ParseObjFile(std::vector<std::string> lines) {
 
             if (!materialLibrary.empty()) {
                 printf("Parsing material library....\n");
-                MaterialLibraryParser().ParseLibrary(materialLibrary);
+                MaterialMap materials;
+                if (!MaterialLibraryParser().ParseLibrary(materialLibrary,
+                                                          &materials)) {
+                    return false;
+                }
             }
 
             LOG(Logger::LogLevel::Debug, std::format(

--- a/src/wavefront/WaveFrontObjLoader.cpp
+++ b/src/wavefront/WaveFrontObjLoader.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "glm/glm.hpp"
 #include "LoggerManager.h"
 #include "WaveFrontObjLoader.h"
+#include "MaterialLibraryParser.h"
 
 namespace Meshborn {
 namespace WaveFront {
@@ -336,7 +337,6 @@ bool ParseObjFile(std::vector<std::string> lines) {
 
         // Texture coordinate [NOT IMPLEMENTED YET!]
         } else if (view.starts_with(TEXTURE_COORDINATE_ELEMENT)) {
-            //std::cout << "Found texture coordinate: " << view << '\n';
             LOG(Logger::LogLevel::Debug, std::format(
                 "Found texture coordinate: {}", view));
 
@@ -354,6 +354,11 @@ bool ParseObjFile(std::vector<std::string> lines) {
                     "Materials library line '{}' is invalid",
                     view));
                 return false;
+            }
+
+            if (!materialLibrary.empty()) {
+                printf("Parsing material library....\n");
+                MaterialLibraryParser().ParseLibrary(materialLibrary);
             }
 
             LOG(Logger::LogLevel::Debug, std::format(

--- a/src/wavefront/WaveFrontObjLoader.h
+++ b/src/wavefront/WaveFrontObjLoader.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define WAVEFRONT_WAVEFRONTOBJLOADER_H_
 #include <string>
 #include <vector>
+#include "BaseWavefrontParser.h"
 
 namespace Meshborn {
 namespace WaveFront {


### PR DESCRIPTION
Changes:
* Implemented a class that implements the materials (.mtl) for a Wavefront object
* Created a Material class for storing material information
* Updated readme to contain more roadmap information
* Added base wavefront parser class for the common functionality between the object and material parsing