### PR TITLE
Implement group and object tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The following Wavefront obj tags are currently supported:
 | Tag                  | Status             | Notes                |
 |:---------------------|:-------------------|:---------------------|
 | f (face)             | :white_check_mark: |                      |
-| g (group)            | :x:                | Not implemented      |
+| g (group)            | :white_check_mark: |                      |
 | l (line element)     | :x:                | Not implemented      |
-| mtllib (materials)   | :x:                | Not implemented      |
-| o (object)           | :x:                | Not implemented      |
+| mtllib (materials)   | :construction:     | Partial implementation |
+| o (object)           | :white_check_mark: |                      |
 | s (Smooth shading )  | :x:                | Not implemented      |
 | usemtl (use material)| :x:                | Not implemented      |
 | v (vertex)           | :white_check_mark: |                      |
@@ -64,5 +64,5 @@ The following functionality is currently supported:
 | Basic material read  | :construction:     | Material read done, handling in obj not done      |
 | Logging              | :white_check_mark: |                                                   |
 | Materials class      | :construction:     | Work on material class in progress                |
-| Model class          | :x:                | Object parsingt needs rework first                |
+| Model class          | :construction:     | Partial implementation for basic functionality    |
 | Unit tests           | :x:                | Unit tests to be started once main core is stable |

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/LoggerManager.h
+++ b/src/LoggerManager.h
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -15,3 +15,4 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "Mesh.h"

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -1,0 +1,17 @@
+/*
+Meshborn
+Copyright (C) 2025 SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -1,0 +1,63 @@
+/*
+Meshborn
+Copyright (C) 2025 SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef MESH_H_
+#define MESH_H_
+#include <string>
+#include <vector>
+
+namespace Meshborn {
+namespace WaveFront {
+
+struct PolygonalFaceElement {
+    PolygonalFaceElement() : vertex(-1), texture(-1), normal(-1) {}
+
+    int vertex;
+    int texture;
+    int normal;
+};
+
+enum class PolygonalFaceType {
+    //  Triangle (3 vertices)
+    TRIANGE,
+
+    //  Quad (4 vertices)
+    QUAD,
+
+    // N-gon (5+ vertices):
+    // Technically allowed by the .obj format, though many parsers or game
+    // engines don’t support them directly.
+    N_GON
+};
+
+struct PolygonalFace {
+    PolygonalFaceType faceType;
+    std::vector<PolygonalFaceElement> elements;
+};
+
+class Mesh {
+ public:
+    std::string name;
+    std::string material;
+    bool materialSet;
+    std::vector<PolygonalFace> faces;
+};
+
+}   // namespace WaveFront
+}   // namespace Meshborn
+
+#endif  // MESH_H_

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MESH_H_
 #include <string>
 #include <vector>
+#include "Structures.h"
 
 namespace Meshborn {
 namespace WaveFront {
@@ -55,6 +56,7 @@ class Mesh {
     std::string material;
     bool materialSet;
     std::vector<PolygonalFace> faces;
+    std::vector<Point3D> vertices;
 };
 
 }   // namespace WaveFront

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -56,7 +56,7 @@ class Mesh {
     std::string material;
     bool materialSet;
     std::vector<PolygonalFace> faces;
-    std::vector<Point3D> vertices;
+    std::vector<Vertex> vertices;
 };
 
 }   // namespace WaveFront

--- a/src/Meshborn.vcxproj
+++ b/src/Meshborn.vcxproj
@@ -131,15 +131,25 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Material.cpp" />
+    <ClCompile Include="Mesh.cpp" />
     <ClCompile Include="Meshborn.cpp" />
     <ClCompile Include="test.cpp" />
-    <ClCompile Include="wavefront\WaveFrontObjLoader.cpp" />
+    <ClCompile Include="wavefront\BaseWavefrontParser.cpp" />
+    <ClCompile Include="wavefront\MaterialLibraryParser.cpp" />
+    <ClCompile Include="wavefront\WaveFrontObjParser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Logger.h" />
     <ClInclude Include="LoggerManager.h" />
+    <ClInclude Include="Material.h" />
+    <ClInclude Include="Mesh.h" />
     <ClInclude Include="Meshborn.h" />
-    <ClInclude Include="wavefront\WaveFrontObjLoader.h" />
+    <ClInclude Include="Model.h" />
+    <ClInclude Include="Structures.h" />
+    <ClInclude Include="wavefront\BaseWavefrontParser.h" />
+    <ClInclude Include="wavefront\MaterialLibraryParser.h" />
+    <ClInclude Include="wavefront\WaveFrontObjParser.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/Meshborn.vcxproj
+++ b/src/Meshborn.vcxproj
@@ -105,7 +105,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;MESHBORN_LOG_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>

--- a/src/Meshborn.vcxproj
+++ b/src/Meshborn.vcxproj
@@ -151,6 +151,10 @@
     <ClInclude Include="wavefront\MaterialLibraryParser.h" />
     <ClInclude Include="wavefront\WaveFrontObjParser.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\.gitignore" />
+    <None Include="..\README.md" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/src/Meshborn.vcxproj.filters
+++ b/src/Meshborn.vcxproj.filters
@@ -8,6 +8,9 @@
     <Filter Include="Wavefront">
       <UniqueIdentifier>{04dac089-3815-4233-aa96-62ec8a7e8e8b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Github">
+      <UniqueIdentifier>{703dcf53-a510-49cf-84b7-2fb6bbfb3497}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="test.cpp" />
@@ -41,5 +44,13 @@
       <Filter>Wavefront</Filter>
     </ClInclude>
     <ClInclude Include="Material.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\.gitignore">
+      <Filter>Github</Filter>
+    </None>
+    <None Include="..\README.md">
+      <Filter>Github</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Meshborn.vcxproj.filters
+++ b/src/Meshborn.vcxproj.filters
@@ -11,17 +11,35 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="test.cpp" />
-    <ClCompile Include="wavefront\WaveFrontObjLoader.cpp">
+    <ClCompile Include="Meshborn.cpp" />
+    <ClCompile Include="Mesh.cpp" />
+    <ClCompile Include="wavefront\BaseWavefrontParser.cpp">
       <Filter>Wavefront</Filter>
     </ClCompile>
-    <ClCompile Include="Meshborn.cpp" />
+    <ClCompile Include="wavefront\MaterialLibraryParser.cpp">
+      <Filter>Wavefront</Filter>
+    </ClCompile>
+    <ClCompile Include="wavefront\WaveFrontObjParser.cpp">
+      <Filter>Wavefront</Filter>
+    </ClCompile>
+    <ClCompile Include="Material.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="wavefront\WaveFrontObjLoader.h">
-      <Filter>Wavefront</Filter>
-    </ClInclude>
     <ClInclude Include="Logger.h" />
     <ClInclude Include="Meshborn.h" />
     <ClInclude Include="LoggerManager.h" />
+    <ClInclude Include="Mesh.h" />
+    <ClInclude Include="Structures.h" />
+    <ClInclude Include="Model.h" />
+    <ClInclude Include="wavefront\BaseWavefrontParser.h">
+      <Filter>Wavefront</Filter>
+    </ClInclude>
+    <ClInclude Include="wavefront\MaterialLibraryParser.h">
+      <Filter>Wavefront</Filter>
+    </ClInclude>
+    <ClInclude Include="wavefront\WaveFrontObjParser.h">
+      <Filter>Wavefront</Filter>
+    </ClInclude>
+    <ClInclude Include="Material.h" />
   </ItemGroup>
 </Project>

--- a/src/Model.h
+++ b/src/Model.h
@@ -1,0 +1,34 @@
+/*
+Meshborn
+Copyright (C) 2025 SwatKat1977
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef MODEL_H_
+#define MODEL_H_
+#include <vector>
+#include "Mesh.h"
+
+namespace Meshborn {
+namespace WaveFront {
+
+class Model {
+ public:
+    std::vector<Mesh> meshes;
+};
+
+}   // namespace WaveFront
+}   // namespace Meshborn
+
+#endif  // MODEL_H_

--- a/src/Structures.h
+++ b/src/Structures.h
@@ -51,6 +51,14 @@ struct TextureCoordinates {
     TextureCoordinates(float u, float v, float w) : u(u), v(v), w(w) {}
 };
 
+
+class Vertex {
+ public:
+    Point4D position;
+    Point3D normal;
+    TextureCoordinates textureCoordinates;
+};
+
 using Point3DList = std::vector<Point3D>;
 using Point4DList = std::vector<Point4D>;
 using TextureCoordinatesList = std::vector<TextureCoordinates>;

--- a/src/Structures.h
+++ b/src/Structures.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifndef STRUCTURES_H_
 #define STRUCTURES_H_
+#include <vector>
 
 namespace Meshborn {
 
@@ -49,6 +50,10 @@ struct TextureCoordinates {
     TextureCoordinates() : u(0), v(0), w(0) {}
     TextureCoordinates(float u, float v, float w) : u(u), v(v), w(w) {}
 };
+
+using Point3DList = std::vector<Point3D>;
+using Point4DList = std::vector<Point4D>;
+using TextureCoordinatesList = std::vector<TextureCoordinates>;
 
 }   // namespace Meshborn
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -93,7 +93,9 @@ int main(int argc, char** argv) {
     std::cout << "Loading '" << filename << "'\n";
 
     try {
-        Meshborn::WaveFront::WaveFrontObjParser().ParseObj(filename);
+        bool status;
+        status = Meshborn::WaveFront::WaveFrontObjParser().ParseObj(filename);
+        std::cout << "[DEBUG] Parse object return status of " << status << "\n";
     }
     catch (std::runtime_error ex) {
         std::cout << "[EXCEPTION] " << ex.what() << "\n";

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <string_view>
 #include <vector>
 #include "Logger.h"
+#include "Model.h"
 
 const std::map<Meshborn::Logger::LogLevel, std::string> LogLevelToString {
     { Meshborn::Logger::LogLevel::Debug,    "DEBUG" },
@@ -92,9 +93,12 @@ int main(int argc, char** argv) {
 
     std::cout << "Loading '" << filename << "'\n";
 
+    Meshborn::WaveFront::Model model;
+
     try {
         bool status;
-        status = Meshborn::WaveFront::WaveFrontObjParser().ParseObj(filename);
+        status = Meshborn::WaveFront::WaveFrontObjParser().ParseObj(filename,
+                                                                    &model);
         std::cout << "[DEBUG] Parse object return status of " << status << "\n";
     }
     catch (std::runtime_error ex) {

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -15,6 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <format>
 #include <iostream>
 #include <vector>
 #include "MaterialLibraryParser.h"

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -714,7 +714,20 @@ bool MaterialLibraryParser::ProcessTagSpecularColorTextureMap(
 
     return true;
 }
-
+/**
+ * Parses a 'map_ns' (specular highlight component) line from a material
+ * library (.mtl) file and extracts the corresponding texture map filename.
+ *
+ * This map typically defines the shininess level or specular exponent map
+ * used in the material shading process.
+ * The line should contain exactly two parts: the keyword and the texture filename.
+ * If valid, the filename is stored in the provided string pointer.
+ *
+ * @param line The line from the .mtl file (e.g., "map_ns specular_map.png").
+ * @param component Pointer to a string where the extracted filename will be stored.
+ * @return true if the specular highlight component line is valid and successfully parsed;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagSpecularHighlightConponent(
     std::string_view line, std::string *component) {
     auto words = SplitElementString(std::string(line));
@@ -730,6 +743,20 @@ bool MaterialLibraryParser::ProcessTagSpecularHighlightConponent(
     return true;
 }
 
+/**
+ * Parses a 'map_d' (alpha texture map) line from a material library (.mtl)
+ * file and extracts the associated texture map filename.
+ *
+ * This line typically specifies the transparency texture used in a material.
+ * It should consist of exactly two parts: the keyword and the filename.
+ * If valid, the filename is stored in the provided string pointer.
+ *
+ * @param line The line from the .mtl file (e.g., "map_d alpha_map.png").
+ * @param map Pointer to a string where the extracted texture map filename
+ *            will be stored.
+ * @return true if the alpha texture map line is valid and successfully parsed;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagAlphaTextureMap(std::string_view line,
                                                        std::string *map) {
     auto words = SplitElementString(std::string(line));
@@ -745,6 +772,20 @@ bool MaterialLibraryParser::ProcessTagAlphaTextureMap(std::string_view line,
     return true;
 }
 
+/**
+ * Parses a 'bump' (bump map) line from a material library (.mtl) file
+ * and extracts the bump map filename.
+ *
+ * The line should contain exactly two elements: the 'bump' keyword and the
+ * associated bump map filename. If the format is valid, the filename is
+ * stored in the provided string pointer.
+ *
+ * @param line The line from the .mtl file (e.g., "bump normal_map.png").
+ * @param map Pointer to a string where the extracted bump map filename
+ *            will be saved.
+ * @return true if the bump map line is valid and successfully parsed;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagBumpMap(std::string_view line,
                                               std::string *map) {
     auto words = SplitElementString(std::string(line));
@@ -760,6 +801,20 @@ bool MaterialLibraryParser::ProcessTagBumpMap(std::string_view line,
     return true;
 }
 
+/**
+ * Parses a 'disp' (displacement map) line from a material library (.mtl) file
+ * and extracts the displacement map filename.
+ *
+ * The input line must consist of exactly two words: the 'disp' keyword
+ * followed by the displacement map filename. If valid, the filename is
+ * stored in the output string.
+ *
+ * @param line The line from the .mtl file (e.g., "disp height.png").
+ * @param map Pointer to a string where the parsed displacement map filename
+ *            will be stored.
+ * @return true if the line is correctly formatted and parsing is successful;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagDisplacementMap(std::string_view line,
                                                       std::string *map) {
     auto words = SplitElementString(std::string(line));
@@ -775,6 +830,20 @@ bool MaterialLibraryParser::ProcessTagDisplacementMap(std::string_view line,
     return true;
 }
 
+/**
+ * Parses a 'decal' line from a material library (.mtl) file and extracts
+ * the stencil decal texture filename.
+ *
+ * The input line must consist of exactly two words: the 'decal' keyword
+ * followed by the texture filename. If valid, the filename is written to
+ * the provided output pointer.
+ *
+ * @param line The line from the .mtl file (e.g., "decal stencil.png").
+ * @param texture Pointer to a string where the parsed texture filename will
+ *                be stored.
+ * @return true if the line is correctly formatted and parsing succeeds;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagStencilDecalTexture(
     std::string_view line, std::string *texture) {
     auto words = SplitElementString(std::string(line));

--- a/src/wavefront/MaterialLibraryParser.cpp
+++ b/src/wavefront/MaterialLibraryParser.cpp
@@ -53,7 +53,26 @@ const char KEYWORD_STENCIL_DECAL_TEXTURE[] = "decal ";
 MaterialLibraryParser::MaterialLibraryParser() {
 }
 
-// bool ParseLibrary(std::string materialFile);
+/**
+ * Parses a material library (.mtl) file and populates a map of materials.
+ * Each material is created based on the tags encountered in the file, and
+ * their properties (e.g., ambient, diffuse, specular colors, textures) are set
+ * accordingly. The function handles various material-related tags such as
+ * 'Ka', 'Kd', 'Ks', 'Ns', etc.
+ *
+ * The process includes handling texture maps, transparency, bump maps, and
+ * optical density, as well as ensuring correct ordering of the tags. If any
+ * tag is out of order or invalid, the function logs an error and returns
+ * false.
+ *
+ * @param materialFile Path to the material file (.mtl) to be parsed.
+ * @param materials A pointer to a map where the parsed materials will be
+ *                  stored, keyed by their names.
+ * @return true if the material file was successfully parsed and all materials
+ *              were processed;
+ *         false if an error occurred during parsing (e.g., invalid tags or
+ *               misordered keywords).
+ */
 bool MaterialLibraryParser::ParseLibrary(std::string materialFile,
                                          MaterialMap *materials) {
     std::vector<std::string> rawLines;
@@ -533,6 +552,21 @@ bool MaterialLibraryParser::ProcessTagSpecularColour(std::string_view line,
     return true;
 }
 
+/**
+ * Parses an 'Ns' (specular exponent) line from a material library (.mtl) file
+ * and extracts the shininess value.
+ *
+ * The specular exponent controls the focus of specular highlights on the
+ * material. Higher values result in smaller, sharper highlights, simulating
+ * glossier surfaces. The line must contain exactly two tokens: the keyword
+ * 'Ns' and a float value.
+ *
+ * @param line The input line from the .mtl file (e.g., "Ns 96.078431").
+ * @param shininess Pointer to a float where the extracted shininess value will
+ *                   be stored.
+ * @return true if the line is well-formed and the value was successfully parsed;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagSpecularExponent(std::string_view line,
                                                        float *shininess) {
     auto words = SplitElementString(std::string(line));
@@ -670,6 +704,22 @@ bool MaterialLibraryParser::ProcessTagIlluminationModel(std::string_view line,
     return true;
 }
 
+/**
+ * Parses a 'map_ka' (ambient texture map) line from a material
+ * library (.mtl) file and extracts the associated texture filename.
+ *
+ * The ambient texture map defines the material’s response to ambient light,
+ * typically used to simulate indirect or environmental lighting.
+ * The line must have exactly two tokens: the keyword and the texture filename.
+ * If valid, the texture filename is assigned to the output string.
+ *
+ * @param line The input line from the .mtl file (e.g., "map_ka ambient.jpg").
+ * @param map Pointer to a string where the extracted texture filename will be
+ *            stored.
+ * @return true if the line is well-formed and the filename was successfully
+ *              parsed;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagAmbientTextureMap(std::string_view line,
                                                         std::string *map) {
     auto words = SplitElementString(std::string(line));
@@ -685,6 +735,20 @@ bool MaterialLibraryParser::ProcessTagAmbientTextureMap(std::string_view line,
     return true;
 }
 
+/**
+ * Parses a 'map_kd' (diffuse texture map) line from a material
+ * library (.mtl) file and extracts the associated texture filename.
+ *
+ * The diffuse texture map defines the base color of the material’s surface
+ * under diffuse lighting. This line must contain exactly two components:
+ * the keyword and the texture filename. If the format is valid, the filename
+ * is assigned to the provided string pointer.
+ *
+ * @param line The line from the .mtl file (e.g., "map_kd brick_diffuse.jpg").
+ * @param map Pointer to a string where the extracted filename will be stored.
+ * @return true if the line is correctly formatted and the filename was extracted;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagDiffuseTextureMap(std::string_view line,
                                                         std::string *map) {
     auto words = SplitElementString(std::string(line));
@@ -700,6 +764,21 @@ bool MaterialLibraryParser::ProcessTagDiffuseTextureMap(std::string_view line,
     return true;
 }
 
+/**
+ * Parses a 'map_ks' (specular color texture map) line from a material
+ * library (.mtl) file and extracts the associated texture filename.
+ *
+ * The specular color map controls the intensity and color of specular
+ * reflections on the surface of the material. This line should have exactly
+ * two elements: the keyword and the texture filename.
+ * If valid, the filename is stored in the provided string pointer.
+ *
+ * @param line The line from the .mtl file (e.g., "map_ks specular_color.png").
+ * @param map Pointer to a string where the extracted filename will be stored.
+ * @return true if the line is correctly formatted and the texture filename was
+ *              extracted;
+ *         false otherwise.
+ */
 bool MaterialLibraryParser::ProcessTagSpecularColorTextureMap(
     std::string_view line, std::string *map) {
     auto words = SplitElementString(std::string(line));
@@ -714,18 +793,21 @@ bool MaterialLibraryParser::ProcessTagSpecularColorTextureMap(
 
     return true;
 }
+
 /**
  * Parses a 'map_ns' (specular highlight component) line from a material
  * library (.mtl) file and extracts the corresponding texture map filename.
  *
  * This map typically defines the shininess level or specular exponent map
  * used in the material shading process.
- * The line should contain exactly two parts: the keyword and the texture filename.
- * If valid, the filename is stored in the provided string pointer.
+ * The line should contain exactly two parts: the keyword and the texture
+ * filename. If valid, the filename is stored in the provided string pointer.
  *
  * @param line The line from the .mtl file (e.g., "map_ns specular_map.png").
- * @param component Pointer to a string where the extracted filename will be stored.
- * @return true if the specular highlight component line is valid and successfully parsed;
+ * @param component Pointer to a string where the extracted filename will be 
+ *                  stored.
+ * @return true if the specular highlight component line is valid and
+ *              successfully parsed;
  *         false otherwise.
  */
 bool MaterialLibraryParser::ProcessTagSpecularHighlightConponent(

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -36,9 +36,6 @@ const char KEYWORD_VECTOR_NORMAL[] = "vn ";
 WaveFrontObjParser::WaveFrontObjParser() {
 }
 
-const char POLYGONAL_FACE_DEBUG_LOG = \
-    "POLYGONAL FACE [triangle] => 1 = {}/{}/{} | 2 = {}/{}/{} | 3 = {}/{}/{}";
-
 bool WaveFrontObjParser::ParseObj(std::string filename) {
     std::vector<std::string> rawLines;
 
@@ -66,7 +63,8 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
 
             if (face.faceType == PolygonalFaceType::TRIANGE) {
                 LOG(Logger::LogLevel::Debug, std::format(
-                    POLYGONAL_FACE_DEBUG_LOG,
+                    "POLYGONAL FACE [triangle] => 1 = {}/{}/{} | 2 = {}/{}/{} "
+                    "| 3 = {}/{}/{}",
                     face.elements[0].vertex,
                     face.elements[0].texture,
                     face.elements[0].normal,
@@ -152,7 +150,7 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
         } else if (view.starts_with(KEYWORD_MATERIAL_LIBRARY)) {
             std::string materialLibrary;
 
-            if (!ParseMaterials(view, materialLibrary)) {
+            if (!ParseMaterials(view, &materialLibrary)) {
                 LOG(Logger::LogLevel::Critical, std::format(
                     "Materials library line '{}' is invalid",
                     view));
@@ -355,7 +353,7 @@ bool WaveFrontObjParser::ParseVertexNormalElement(
  *         succeeds; false otherwise.
  */
 bool WaveFrontObjParser::ParseMaterials(std::string_view element,
-                                        std::string &materialLibrary) {
+                                        std::string *materialLibrary) {
     auto words = SplitElementString(std::string(element));
 
     // Requires 2 words (keyword and material_file)
@@ -370,7 +368,7 @@ bool WaveFrontObjParser::ParseMaterials(std::string_view element,
             "Materials library '{}' is missing/inaccessible",
             words[1]));
     } else {
-        materialLibrary = words[1];
+        *materialLibrary = words[1];
     }
 
     return true;

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -36,6 +36,9 @@ const char KEYWORD_VECTOR_NORMAL[] = "vn ";
 WaveFrontObjParser::WaveFrontObjParser() {
 }
 
+const char POLYGONAL_FACE_DEBUG_LOG = \
+    "POLYGONAL FACE [triangle] => 1 = {}/{}/{} | 2 = {}/{}/{} | 3 = {}/{}/{}";
+
 bool WaveFrontObjParser::ParseObj(std::string filename) {
     std::vector<std::string> rawLines;
 
@@ -63,7 +66,7 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
 
             if (face.faceType == PolygonalFaceType::TRIANGE) {
                 LOG(Logger::LogLevel::Debug, std::format(
-                    "POLYGONAL FACE [triangle] => 1 = {}/{}/{} | 2 = {}/{}/{} | 3 = {}/{}/{}",
+                    POLYGONAL_FACE_DEBUG_LOG,
                     face.elements[0].vertex,
                     face.elements[0].texture,
                     face.elements[0].normal,
@@ -75,14 +78,16 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
                     face.elements[2].normal));
             } else {
                 std::string faceType;
-                if (face.faceType == PolygonalFaceType::QUAD) faceType = "Quad";
-                else faceType = "N-Gon";
+                if (face.faceType == PolygonalFaceType::QUAD) {
+                    faceType = "Quad";
+                } else {
+                    faceType = "N-Gon";
+                }
 
                 LOG(Logger::LogLevel::Debug,
                      std::format("POLYGONAL FACE ({}) =>", faceType));
 
                 for (size_t i = 0; i < face .elements.size(); ++i) {
-
                     LOG(Logger::LogLevel::Debug, std::format(
                         "    {} = {}/{}/{}",
                         i,
@@ -90,7 +95,6 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
                         face.elements[i].texture,
                         face.elements[i].normal));
                 }
-
             }
             faces.push_back(face);
 
@@ -250,7 +254,7 @@ bool WaveFrontObjParser::ParsePolygonalFaceElement(std::string_view element,
         face->elements.push_back(faceElement);
     }
 
-    switch((words.size() -1)) {
+    switch ((words.size() -1)) {
         // 3 vertex - triangle
         case 3:
             face->faceType = PolygonalFaceType::TRIANGE;

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -60,6 +60,7 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
             std::cout << "GROUP " << view << "\n";
             std::string groupName;
             if (!ParseGroupElement(view, &groupName)) {
+                return false;
             }
 
         //         } else if (view.starts_with(KEYWORD_VECTOR)) {
@@ -67,7 +68,7 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
             std::cout << "OBJECT " << view << "\n";
             std::string objectName;
             if (!ParseObjectElement(view, &objectName)) {
-
+                return false;
             }
 
         // Polygonal face

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -107,13 +107,12 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
                 currentMesh->material != currentMaterial) {
 
                 if (currentMesh) {
-                    LOG(Logger::LogLevel::Debug, "Moving along ....");
-
                     if (!FinaliseVertices(currentMesh,
                         vertexPositions,
                         vertexNormals,
                         textureCoordinates)) {
-                        printf("failed to finalise\n");
+                        LOG(Logger::LogLevel::Debug,
+                            "Failed to finalise a mesh");
                         return false;
                     }
                 }
@@ -223,9 +222,6 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
 
         // Use material [NOT IMPLEMENTED YET!]
         } else if (view.starts_with(KEYWORD_USE_MATERIAL)) {
-            LOG(Logger::LogLevel::Debug, std::format(
-                "Use material element: {}", view));
-
             std::string useMaterialName;
             if (!ParseUseMaterial(view, &useMaterialName)) {
                 return false;

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -53,23 +53,32 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
     std::vector<TextureCoordinates> textureCoordinates;
     std::vector<PolygonalFace> faces;
 
+    std::string currentObjectName = "default";
+    std::string currentGroupName = "default";
+
     for (const auto& line : rawLines) {
         std::string_view view(line);
 
         if (view.starts_with(KEYWORD_GROUP)) {
-            std::cout << "GROUP " << view << "\n";
             std::string groupName;
             if (!ParseGroupElement(view, &groupName)) {
                 return false;
             }
 
+            currentGroupName = groupName;
+            LOG(Logger::LogLevel::Debug,
+                std::format("GROUP => {}", currentGroupName));
+
         //         } else if (view.starts_with(KEYWORD_VECTOR)) {
         } else if (view.starts_with(KEYWORD_OBJECT)) {
-            std::cout << "OBJECT " << view << "\n";
             std::string objectName;
             if (!ParseObjectElement(view, &objectName)) {
                 return false;
             }
+
+            currentObjectName = objectName;
+            LOG(Logger::LogLevel::Debug,
+                std::format("OBJECT => {}", currentObjectName));
 
         // Polygonal face
         } else if (view.starts_with(KEYWORD_POLYGONAL_FACE)) {

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -298,6 +298,8 @@ bool WaveFrontObjParser::ParsePolygonalFaceElement(std::string_view element,
         // Format: v
         if (firstSlash == std::string::npos) {
             faceElement.vertex = std::stoi(rawFaceelement);
+            faceElement.texture = -1;
+            faceElement.normal = -1;
 
         // Format: v/vt
         } else if (secondSlash == std::string::npos) {
@@ -305,11 +307,13 @@ bool WaveFrontObjParser::ParsePolygonalFaceElement(std::string_view element,
                 0, firstSlash));
             faceElement.texture = std::stoi(rawFaceelement.substr(
                 firstSlash + 1));
+            faceElement.normal = -1;
 
         // Format: v//vn
         } else if (secondSlash == firstSlash + 1) {
             faceElement.vertex = std::stoi(rawFaceelement.substr(
                 0, firstSlash));
+            faceElement.texture = -1;
             faceElement.normal = std::stoi(rawFaceelement.substr(
                 secondSlash + 1));
 

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -38,7 +38,8 @@ const char KEYWORD_VECTOR_NORMAL[] = "vn ";
 WaveFrontObjParser::WaveFrontObjParser() {
 }
 
-bool WaveFrontObjParser::ParseObj(std::string filename) {
+bool WaveFrontObjParser::ParseObj(std::string filename,
+                                  Model* model) {
     std::vector<std::string> rawLines;
 
     try {

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -576,9 +576,9 @@ bool WaveFrontObjParser::FinaliseVertices(
     mesh->vertices.clear();
 
     for (const auto& face : mesh->faces) {
-        Vertex vertex;
-
         for (const auto& elem : face.elements) {
+            Vertex vertex;
+
             if (elem.vertex < 1 ||
                 elem.vertex > static_cast<int>(positions.size())) {
                 return false;
@@ -603,6 +603,9 @@ bool WaveFrontObjParser::FinaliseVertices(
                 vertex.textureCoordinates =
                     textureCoordinates[elem.texture - 1];
             }
+
+            mesh->vertices.push_back(vertex);
+
         }
     }
 

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -38,6 +38,20 @@ const char KEYWORD_VECTOR_NORMAL[] = "vn ";
 WaveFrontObjParser::WaveFrontObjParser() {
 }
 
+/**
+ * Parses a Wavefront .obj file and fills the provided model object with data.
+ *
+ * Reads the specified .obj file, parsing vertex positions, normals,
+ * texture coordinates, faces, groups, and objects. Meshes are created
+ * based on object/group/material changes. Material libraries may also
+ * be parsed if specified. This parser supports triangle, quad, and
+ * n-gon polygonal faces.
+ *
+ * @param filename The path to the .obj file to be parsed.
+ * @param model Pointer to the Model object to populate.
+ * @return true if parsing succeeds, false if any error occurs.
+ * @throws std::runtime_error if the file cannot be read.
+ */
 bool WaveFrontObjParser::ParseObj(std::string filename,
                                   Model* model) {
     std::vector<std::string> rawLines;
@@ -235,6 +249,16 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
     return true;
 }
 
+/**
+ * Parses a group name element from a string and stores the result.
+ *
+ * Expects at least two space-separated words: keyword and group name.
+ * Extracts the name and assigns it to the provided output string.
+ *
+ * @param element The input string containing the group definition.
+ * @param groupName Output pointer for the parsed group name.
+ * @return true on success, false if input format is invalid.
+ */
 bool WaveFrontObjParser::ParseGroupElement(std::string_view element,
                                            std::string* groupName) {
     auto words = SplitElementString(std::string(element));
@@ -248,6 +272,16 @@ bool WaveFrontObjParser::ParseGroupElement(std::string_view element,
     return true;
 }
 
+/**
+ * Parses an object name element from a string and stores the result.
+ *
+ * Expects at least two space-separated words: keyword and object name.
+ * Extracts the name and assigns it to the provided output string.
+ *
+ * @param element The input string containing the object definition.
+ * @param objectName Output pointer for the parsed object name.
+ * @return true on success, false if input format is invalid.
+ */
 bool WaveFrontObjParser::ParseObjectElement(std::string_view element,
                                             std::string* objectName) {
     auto words = SplitElementString(std::string(element));

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -58,7 +58,6 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
     std::string currentMaterial = "";
     std::string currentMeshName = "default:default";
     Mesh* currentMesh = nullptr;
-    std::vector<Mesh> meshes;
 
     for (const auto& line : rawLines) {
         std::string_view view(line);
@@ -74,7 +73,6 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
             LOG(Logger::LogLevel::Debug,
                 std::format("GROUP => {}", currentGroupName));
 
-        //         } else if (view.starts_with(KEYWORD_VECTOR)) {
         } else if (view.starts_with(KEYWORD_OBJECT)) {
             std::string objectName;
             if (!ParseObjectElement(view, &objectName)) {
@@ -134,8 +132,8 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
                 Mesh newMesh;
                 newMesh.name = currentMeshName;
                 newMesh.material = currentMaterial;
-                meshes.push_back(std::move(newMesh));
-                currentMesh = &meshes.back();
+                model->meshes.push_back(std::move(newMesh));
+                currentMesh = &model->meshes.back();
 
                 LOG(Logger::LogLevel::Debug,
                     std::format("NEW MESH => name: {}, material: {}",

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -51,7 +51,6 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
     std::vector<Point4D> vertexPositions;
     std::vector<Point3D> vertexNormals;
     std::vector<TextureCoordinates> textureCoordinates;
-    std::vector<PolygonalFace> faces;
 
     std::string currentObjectName = "default";
     std::string currentGroupName = "default";
@@ -144,7 +143,6 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
             }
 
             currentMesh->faces.push_back(face);
-            // faces.push_back(face);
 
         // Vertex position
         } else if (view.starts_with(KEYWORD_VECTOR)) {

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -15,6 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <format>
 #include <fstream>
 #include <iostream>         /// TEMPORARY - TO BE DELETED!!!
 #include <sstream>

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -58,10 +58,17 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
 
         if (view.starts_with(KEYWORD_GROUP)) {
             std::cout << "GROUP " << view << "\n";
+            std::string groupName;
+            if (!ParseGroupElement(view, &groupName)) {
+            }
 
         //         } else if (view.starts_with(KEYWORD_VECTOR)) {
         } else if (view.starts_with(KEYWORD_OBJECT)) {
             std::cout << "OBJECT " << view << "\n";
+            std::string objectName;
+            if (!ParseObjectElement(view, &objectName)) {
+
+            }
 
         // Polygonal face
         } else if (view.starts_with(KEYWORD_POLYGONAL_FACE)) {
@@ -185,6 +192,32 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
         }
     }
 
+    return true;
+}
+
+bool WaveFrontObjParser::ParseGroupElement(std::string_view element,
+                                           std::string* groupName) {
+    auto words = SplitElementString(std::string(element));
+    if (words.size() < 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Group '{}' is invalid", element));
+        return false;
+    }
+
+    *groupName = words[1];
+    return true;
+}
+
+bool WaveFrontObjParser::ParseObjectElement(std::string_view element,
+                                            std::string* objectName) {
+    auto words = SplitElementString(std::string(element));
+    if (words.size() < 2) {
+        LOG(Logger::LogLevel::Critical, std::format(
+            "Object '{}' is invalid", element));
+        return false;
+    }
+
+    *objectName = words[1];
     return true;
 }
 

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -101,11 +101,9 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
 
         // Polygonal face
         } else if (view.starts_with(KEYWORD_POLYGONAL_FACE)) {
-
             if (!currentMesh ||
                 currentMesh->name != currentMeshName ||
                 currentMesh->material != currentMaterial) {
-
                 if (currentMesh) {
                     if (!FinaliseVertices(currentMesh,
                         vertexPositions,
@@ -570,6 +568,19 @@ bool WaveFrontObjParser::ParseTextureCoordinate(
     return true;
 }
 
+/**
+ * Parses a 'usemtl' line from a Wavefront .obj file and extracts the
+ * material name.
+ *
+ * Expects the input string to contain exactly two words: the 'usemtl'
+ * keyword followed by the material name. If valid, the material name is
+ * written to the provided output pointer.
+ *
+ * @param element The line from the .obj file (e.g., "usemtl MaterialName").
+ * @param material Pointer to a string where the parsed material name will
+ *                 be stored.
+ * @return true if parsing succeeds; false if the line is malformed.
+ */
 bool WaveFrontObjParser::ParseUseMaterial(std::string_view element,
                                           std::string* material) {
     auto words = SplitElementString(std::string(element));
@@ -644,7 +655,6 @@ bool WaveFrontObjParser::FinaliseVertices(
             }
 
             mesh->vertices.push_back(vertex);
-
         }
     }
 

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -26,7 +26,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Meshborn {
 namespace WaveFront {
 
+const char KEYWORD_GROUP[] = "g ";
 const char KEYWORD_MATERIAL_LIBRARY[] = "mtllib ";
+const char KEYWORD_OBJECT[] = "o ";
 const char KEYWORD_POLYGONAL_FACE[] = "f ";
 const char KEYWORD_TEXTURE_COORDINATE[] = "vt ";
 const char KEYWORD_USE_MATERIAL[] = "usemtl ";
@@ -54,8 +56,15 @@ bool WaveFrontObjParser::ParseObj(std::string filename) {
     for (const auto& line : rawLines) {
         std::string_view view(line);
 
+        if (view.starts_with(KEYWORD_GROUP)) {
+            std::cout << "GROUP " << view << "\n";
+
+        //         } else if (view.starts_with(KEYWORD_VECTOR)) {
+        } else if (view.starts_with(KEYWORD_OBJECT)) {
+            std::cout << "OBJECT " << view << "\n";
+
         // Polygonal face
-        if (view.starts_with(KEYWORD_POLYGONAL_FACE)) {
+        } else if (view.starts_with(KEYWORD_POLYGONAL_FACE)) {
             PolygonalFace face;
             if (!ParsePolygonalFaceElement(view, &face)) {
                 return false;

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -68,7 +68,7 @@ class WaveFrontObjParser : public BaseWavefrontParser {
                                   Point3D* vectorNormalElement);
 
     bool ParseMaterials(std::string_view element,
-                        std::string &materialLibrary);
+                        std::string *materialLibrary);
 
     bool ParseTextureCoordinate(std::string_view element,
                                 TextureCoordinates *coordinates);

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "BaseWavefrontParser.h"
 #include "../Structures.h"
 #include "../Mesh.h"
+#include "../Model.h"
 
 namespace Meshborn {
 namespace WaveFront {
@@ -30,7 +31,7 @@ class WaveFrontObjParser : public BaseWavefrontParser {
  public:
     WaveFrontObjParser();
 
-    bool ParseObj(std::string filename);
+    bool ParseObj(std::string filename, Model* model);
 
  private:
      bool ParseGroupElement(std::string_view element,

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -58,7 +58,6 @@ class WaveFrontObjParser : public BaseWavefrontParser {
     bool ParseObj(std::string filename);
 
  private:
-
      bool ParseGroupElement(std::string_view element,
                             std::string* face);
 

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -55,6 +55,9 @@ class WaveFrontObjParser : public BaseWavefrontParser {
     bool ParseTextureCoordinate(std::string_view element,
                                 TextureCoordinates *coordinates);
 
+    bool ParseUseMaterial(std::string_view element,
+                          std::string *material);
+
     bool FinaliseVertices(Mesh *mesh,
                           const Point4DList& positions,
                           const Point3DList& normals,

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -58,6 +58,13 @@ class WaveFrontObjParser : public BaseWavefrontParser {
     bool ParseObj(std::string filename);
 
  private:
+
+     bool ParseGroupElement(std::string_view element,
+                            std::string* face);
+
+    bool ParseObjectElement(std::string_view element,
+                            std::string* face);
+
     bool ParseVectorElement(std::string_view element,
                             Point4D* vectorElement);
 

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -33,8 +33,22 @@ struct PolygonalFaceElement {
     int normal;
 };
 
+enum class PolygonalFaceType {
+    //  Triangle (3 vertices)
+    TRIANGE,
+
+    //  Quad (4 vertices)
+    QUAD,
+
+    // N-gon (5+ vertices):
+    // Technically allowed by the .obj format, though many parsers or game
+    // engines don’t support them directly.
+    N_GON
+};
+
 struct PolygonalFace {
-    PolygonalFaceElement elements[3];
+    PolygonalFaceType faceType;
+    std::vector<PolygonalFaceElement> elements;
 };
 
 class WaveFrontObjParser : public BaseWavefrontParser {

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -21,35 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include "BaseWavefrontParser.h"
 #include "../Structures.h"
+#include "../Mesh.h"
 
 namespace Meshborn {
 namespace WaveFront {
-
-struct PolygonalFaceElement {
-    PolygonalFaceElement() : vertex(-1), texture(-1), normal(-1) {}
-
-    int vertex;
-    int texture;
-    int normal;
-};
-
-enum class PolygonalFaceType {
-    //  Triangle (3 vertices)
-    TRIANGE,
-
-    //  Quad (4 vertices)
-    QUAD,
-
-    // N-gon (5+ vertices):
-    // Technically allowed by the .obj format, though many parsers or game
-    // engines don’t support them directly.
-    N_GON
-};
-
-struct PolygonalFace {
-    PolygonalFaceType faceType;
-    std::vector<PolygonalFaceElement> elements;
-};
 
 class WaveFrontObjParser : public BaseWavefrontParser {
  public:

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -54,6 +54,11 @@ class WaveFrontObjParser : public BaseWavefrontParser {
 
     bool ParseTextureCoordinate(std::string_view element,
                                 TextureCoordinates *coordinates);
+
+    bool FinaliseVertices(Mesh *mesh,
+                          const Point4DList& positions,
+                          const Point3DList& normals,
+                          const TextureCoordinatesList& textureCoordinates);
 };
 
 }   // namespace WaveFront


### PR DESCRIPTION
Change to implement model and mesh integration:
* Minor fixes to header strings
* Implemented a Mesh class that handles an individual mesh for a model.
* Implemented a Model class that handles a loaded model.
* Fixed Visual Studio project
* Added Vertex structure, which is required by Mesh into Structures.h
* Added support for splitting the model into multiple meshes if a group/object or material changed.