### PR TITLE
Material in mesh

### DIFF
--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace Meshborn {
 
-    /**
+ /**
  * @brief Constructs a new Material with the given name.
  * 
  * Initializes the ambient colour to black (0, 0, 0) and marks it as unset.

--- a/src/Material.h
+++ b/src/Material.h
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/Material.h
+++ b/src/Material.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef MATERIAL_H_
 #define MATERIAL_H_
 #include <string>
+#include <unordered_map>
 #include "Structures.h"
 
 namespace Meshborn {
@@ -136,6 +137,8 @@ class Material {
     std::string stencilDecalTexture_;
     bool stencilDecalTextureSet_;
 };
+
+using MaterialMap = std::unordered_map<std::string, std::shared_ptr<Material>>;
 
 }   // namespace Meshborn
 

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -45,16 +45,26 @@ enum class PolygonalFaceType {
     N_GON
 };
 
+/**
+ * Represents a single polygonal face in a 3D mesh.
+ *
+ * A face consists of one or more elements, each of which typically references
+ * a vertex, texture coordinate, and/or normal index.
+ */
 struct PolygonalFace {
     PolygonalFaceType faceType;
     std::vector<PolygonalFaceElement> elements;
 };
 
+/**
+ * Represents a 3D mesh consisting of vertices and polygonal faces.
+ *
+ * A mesh may also be associated with a name and material identifier.
+ */
 class Mesh {
  public:
     std::string name;
     std::string material;
-    bool materialSet;
     std::vector<PolygonalFace> faces;
     std::vector<Vertex> vertices;
 };

--- a/src/Meshborn.cpp
+++ b/src/Meshborn.cpp
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -20,6 +20,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace Meshborn {
 
+/**
+ * Sets the global logger instance.
+ *
+ * Transfers ownership of the provided logger to the LoggerManager singleton,
+ * replacing any existing logger. This allows centralized control over
+ * logging behavior throughout the application.
+ *
+ * @param logger A unique pointer to a new ILogger implementation.
+ */
 void SetLogger(std::unique_ptr<Logger::ILogger> logger) {
     Logger::LoggerManager::Instance().SetLogger(std::move(logger));
 }

--- a/src/Meshborn.h
+++ b/src/Meshborn.h
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/Model.h
+++ b/src/Model.h
@@ -27,8 +27,13 @@ namespace WaveFront {
 
 class Model {
  public:
+    Model() : totalMeshes(0), totalMaterials(0) {}
+
     std::vector<Mesh> meshes;
+    unsigned int totalMeshes;
+
     MaterialMap materials;
+    unsigned int totalMaterials;
 };
 
 }   // namespace WaveFront

--- a/src/Model.h
+++ b/src/Model.h
@@ -17,7 +17,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifndef MODEL_H_
 #define MODEL_H_
+#include <map>
 #include <vector>
+#include "Material.h"
 #include "Mesh.h"
 
 namespace Meshborn {
@@ -26,6 +28,7 @@ namespace WaveFront {
 class Model {
  public:
     std::vector<Mesh> meshes;
+    MaterialMap materials;
 };
 
 }   // namespace WaveFront

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -32,30 +32,6 @@ const std::map<Meshborn::Logger::LogLevel, std::string> LogLevelToString {
     { Meshborn::Logger::LogLevel::Critical, "CRITICAL" }
 };
 
-class Vertex {
- public:
-    Vertex(float x, float y, float z) :
-        x_(x), y_(y), z_(z), w_(DEFAULT_W_VALUE) {}
-
-    Vertex(float x, float y, float z, float w) :
-        x_(x), y_(y), z_(z), w_(w) {}
-
-    float X() const { return x_; }
-    float Y() const { return y_; }
-    float Z() const { return z_; }
-    float W() const { return w_; }
-
- private:
-    Vertex() = delete;  // No default construction allowed
-
-    const float DEFAULT_W_VALUE = 1.0f;
-
-    float x_;
-    float y_;
-    float z_;
-    float w_;
-};
-
 #include "wavefront/WaveFrontObjParser.h"
 #include "Meshborn.h"
 #include "Logger.h"
@@ -70,7 +46,6 @@ class ConsoleLogger: public Meshborn::Logger::ILogger {
                   << message << std::endl;
     }
 };
-
 
 int main(int argc, char** argv) {
     std::string filename;
@@ -97,8 +72,8 @@ int main(int argc, char** argv) {
 
     try {
         bool status;
-        status = Meshborn::WaveFront::WaveFrontObjParser().ParseObj(filename,
-                                                                    &model);
+        auto model = Meshborn::WaveFront::WaveFrontObjParser().ParseObj(filename);
+        status = (!model) ? false : true;
         std::cout << "[DEBUG] Parse object return status of " << status << "\n";
     }
     catch (std::runtime_error ex) {

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -25,6 +25,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Meshborn {
 namespace WaveFront {
 
+/**
+ * Splits a space-delimited string into individual tokens.
+ *
+ * This function takes a string and splits it into substrings using whitespace
+ * as the delimiter. Consecutive spaces are treated as a single delimiter.
+ *
+ * @param str The input string to split.
+ * @return A vector of strings containing each token in the original string.
+ */
 std::vector<std::string> BaseWavefrontParser::SplitElementString(
     const std::string& str) {
     std::vector<std::string> tokens;
@@ -38,6 +47,18 @@ std::vector<std::string> BaseWavefrontParser::SplitElementString(
     return tokens;
 }
 
+/**
+ * Reads a text file line by line, filtering out empty lines and comments.
+ *
+ * This function opens the specified file and reads its contents line by line.
+ * It ignores lines that are empty or begin with the comment character '#'.
+ * On Windows systems, it also removes any carriage return characters ('\r')
+ * from the end of each line.
+ *
+ * @param filename The path to the file to read.
+ * @return A vector of strings, each representing a relevant line from the file.
+ * @throws std::runtime_error if the file cannot be opened.
+ */
 std::vector<std::string> BaseWavefrontParser::ReadFile(
     const std::string& filename) {
     std::vector<std::string> lines;
@@ -63,6 +84,20 @@ std::vector<std::string> BaseWavefrontParser::ReadFile(
     return lines;
 }
 
+/**
+ * Checks whether a given line starts with a specific prefix, ignoring any
+ * leading whitespace characters.
+ *
+ * This function skips over any leading whitespace (spaces, tabs, etc.) in the
+ * input line before comparing the start of the line with the given prefix.
+ * The comparison is case-sensitive and does not trim whitespace from the
+ * prefix.
+ *
+ * @param line The string to check.
+ * @param prefix The prefix to look for at the start of the line.
+ * @return true if the line starts with the prefix after skipping leading whitespace,
+ *         false otherwise.
+ */
 bool BaseWavefrontParser::StartsWith(const std::string& line,
                                      const std::string& prefix) {
     size_t i = 0;
@@ -73,6 +108,20 @@ bool BaseWavefrontParser::StartsWith(const std::string& line,
     return line.compare(i, prefix.length(), prefix) == 0;
 }
 
+/**
+ * Parses a string into a floating-point (float) value. This function checks
+ * for errors during the conversion, such as out-of-range values and the presence
+ * of invalid characters in the input string.
+ *
+ * The function uses `strtof` to convert the string to a `float`. If the input
+ * is not a valid float or contains extra non-numeric characters, or if the
+ * resulting value is out of the representable range for floats, the function
+ * returns false.
+ *
+ * @param str The string to be parsed into a float.
+ * @param out A pointer to a float where the parsed result will be stored if successful.
+ * @return true if the string was successfully parsed into a valid float, false otherwise.
+ */
 bool BaseWavefrontParser::ParseFloat(const char* str, float *out) {
     errno = 0;
     char* end;
@@ -82,6 +131,22 @@ bool BaseWavefrontParser::ParseFloat(const char* str, float *out) {
     return true;
 }
 
+/**
+ * Parses a string into an integer (int) value. The function handles potential
+ * errors that may arise during the conversion process, including out-of-range
+ * values and invalid input formats.
+ *
+ * This function uses `std::strtoll` to perform the conversion, ensuring that
+ * the value is within the valid range of an integer (`INT_MIN` to `INT_MAX`).
+ * If the conversion fails due to invalid characters or out-of-range values,
+ * the function will return false.
+ *
+ * @param str The string to be parsed into an integer.
+ * @param out A pointer to an integer where the result will be stored if the
+ *            parsing is successful.
+ * @return true if the string was successfully parsed into a valid integer,
+ *         false otherwise.
+ */
 bool BaseWavefrontParser::ParseInt(const char* str, int* out) {
     errno = 0;
     char* end;

--- a/src/wavefront/BaseWavefrontParser.cpp
+++ b/src/wavefront/BaseWavefrontParser.cpp
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/wavefront/BaseWavefrontParser.h
+++ b/src/wavefront/BaseWavefrontParser.h
@@ -1,6 +1,6 @@
 /*
 Meshborn
-Copyright (C) 2025  SwatKat1977
+Copyright (C) 2025 SwatKat1977
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/wavefront/MaterialLibraryParser.h
+++ b/src/wavefront/MaterialLibraryParser.h
@@ -19,15 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define WAVEFRONT_MATERIALLIBRARYPARSER_H_
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include "BaseWavefrontParser.h"
 #include "Material.h"
 
 namespace Meshborn {
 namespace WaveFront {
-
-using MaterialMap = std::unordered_map<std::string, std::shared_ptr<Material>>;
-
 
 class MaterialLibraryParser : public BaseWavefrontParser {
  public:

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -218,7 +218,7 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
                 coordinates.w));
             textureCoordinates.push_back(coordinates);
 
-        // Use material [NOT IMPLEMENTED YET!]
+        // Use material
         } else if (view.starts_with(KEYWORD_USE_MATERIAL)) {
             std::string useMaterialName;
             if (!ParseUseMaterial(view, &useMaterialName)) {
@@ -230,7 +230,7 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
             LOG(Logger::LogLevel::Debug, std::format(
                 "USE MATERIAL => {}", currentMaterial));
 
-        // Material library [NOT IMPLEMENTED YET!]
+        // Material library
         } else if (view.starts_with(KEYWORD_MATERIAL_LIBRARY)) {
             std::string materialLibrary;
 
@@ -242,10 +242,8 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
             }
 
             if (!materialLibrary.empty()) {
-                printf("Parsing material library....\n");
-                MaterialMap materials;
                 if (!MaterialLibraryParser().ParseLibrary(materialLibrary,
-                                                          &materials)) {
+                                                          &model->materials)) {
                     std::cout << "ERR parsing material library\n";
                     return false;
                 }

--- a/src/wavefront/WaveFrontObjParser.cpp
+++ b/src/wavefront/WaveFrontObjParser.cpp
@@ -249,8 +249,11 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
                 }
             }
 
+            model->totalMaterials = model->materials.size();
+
             LOG(Logger::LogLevel::Debug,
-                std::format("MATERIALS LIBRARY => {}", view));
+                std::format("MATERIALS LIBRARY => {} ~ count = {}",
+                            view, model->totalMaterials));
 
         } else {
             LOG(Logger::LogLevel::Debug,
@@ -262,6 +265,8 @@ bool WaveFrontObjParser::ParseObj(std::string filename,
         FinaliseVertices(currentMesh, vertexPositions, vertexNormals,
                          textureCoordinates);
     }
+
+    model->totalMeshes = model->meshes.size();
 
     return true;
 }

--- a/src/wavefront/WaveFrontObjParser.h
+++ b/src/wavefront/WaveFrontObjParser.h
@@ -31,7 +31,7 @@ class WaveFrontObjParser : public BaseWavefrontParser {
  public:
     WaveFrontObjParser();
 
-    bool ParseObj(std::string filename, Model* model);
+    std::unique_ptr<Model> ParseObj(std::string filename);
 
  private:
      bool ParseGroupElement(std::string_view element,


### PR DESCRIPTION
Work on implementing materials for a Model/mesh. The change does not validate all of the entries of the material yet, that is due in a future update.

Changes:

NEW:
* Added Materials to Model
* The total number of materials is calculated as we go along, so getting the size is done by getting the value of the member variable
* The total number of meshes is calculated as we go along,g so getting the size is done by getting the value of the member variable

UPDATES:
* Added missing docstrings
* Tidied up existing headers to fix typo
* Removed flag for material set in Mesh, that is implied if emptied now
* Object parser main parsing function signature has changed to improve usability